### PR TITLE
Improve error message

### DIFF
--- a/docs/src/content/docs/api.mdx
+++ b/docs/src/content/docs/api.mdx
@@ -258,6 +258,7 @@ The `<color-input>` element exposes several CSS parts for styling with the `::pa
 - `trigger` - The button that opens the picker
 - `chip` - Color swatch inside the trigger button
 - `input` - Inline text field for direct color entry
+- `error` - Text with color parsing error message
 - `panel` - Popover container
 - `output` - CSS color string display
 - `gamut` - Gamut badge (srgb/p3/rec2020/xyz)

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -36,7 +36,7 @@
 /* Trigger button: now only contains the color chip/swatch */
 button {
   border: 1px solid color-mix(in oklab, var(--canvas-text), var(--canvas) 80%);
-  outline-offset: 5px;
+  outline-offset: 2px;
 
   &.trigger {
     flex-shrink: 0;
@@ -77,7 +77,7 @@ button {
   background: color-mix(in oklab, var(--canvas-text), var(--canvas) 92%);
   color: var(--canvas-text);
   box-shadow: var(--shadow-inner);
-  outline-offset: 5px;
+  outline-offset: 2px;
 
   &[aria-invalid="true"] {
     outline-color: red;
@@ -86,7 +86,7 @@ button {
 
 .error-message {
   position: absolute;
-  top: -1.5rem;
+  bottom: -1.5rem;
   left: 0;
   font-size: 12px;
   color: #ef4444;

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -14,7 +14,7 @@ export function createTemplate(): HTMLTemplateElement {
     <span class="chip" part="chip"></span>
   </button>
   <div class="input-wrapper">
-    <span class="error-message" role="alert" aria-live="polite"></span>
+    <span class="error-message" part="error" role="alert" aria-live="polite"></span>
     <input type="text" class="text-input" part="input" aria-label="Color value" title="Color value" aria-invalid="false" spellcheck="false" />
   </div>
   <div class="panel" popover="auto" part="panel">


### PR DESCRIPTION
Ref https://github.com/argyleink/css-color-component/issues/24

<img width="282" height="125" alt="Screenshot 2025-11-22 at 16 09 25" src="https://github.com/user-attachments/assets/3fc94612-c17f-4444-acd8-56edd30e0541" />


- reduced outline offset (fixed error overlapping in safari)
- exposed ::part(error)
- moved error below input to not overlap label which is often above input