### PR TITLE
Reduce output size to avoid popover jumping

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -156,7 +156,6 @@ button {
 /* Preview area: visual swatch + colorspace selector + current value output + gamut badge */
 .preview {
   position: relative;
-  min-inline-size: 35ch;
   display: grid;
   align-content: end;
   justify-items: start;


### PR DESCRIPTION
before

https://github.com/user-attachments/assets/8996237b-b424-497e-b63e-fa9620bc21a7

after

<img width="535" height="410" alt="Screenshot 2025-12-04 at 18 28 20" src="https://github.com/user-attachments/assets/a205982e-0b5e-4d46-b263-9781712ea16a" />
