### PR TITLE
Prototype: OKLCH area slice on the GPU (current vs custom shader vs @colordx/gpu)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,7 +23,8 @@ export default defineConfig({
         { label: 'Home', slug: 'index' },
         { label: 'API Reference', slug: 'api' },
         { label: 'Styling', slug: 'styling' },
-        { label: 'Advanced', slug: 'advanced' }
+        { label: 'Advanced', slug: 'advanced' },
+        { label: 'GPU Comparison (prototype)', slug: 'gpu-comparison' }
       ]
     }),
     mdx()
@@ -47,7 +48,7 @@ export default defineConfig({
     },
     optimizeDeps: {
       // Include component dependencies so they're pre-bundled
-      include: ['@preact/signals-core', 'colorjs.io'],
+      include: ['@preact/signals-core', 'colorjs.io', '@colordx/gpu'],
       // Exclude the component itself so changes are picked up
       exclude: ['color-input']
     }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^4.3.8",
         "@astrojs/starlight": "^0.36.1",
-        "@colordx/gpu": "^0.2.1",
+        "@colordx/gpu": "^0.5.0",
         "@preact/signals-core": "^1.6.0",
         "astro": "^5.6.1",
         "colorjs.io": "^0.6.1",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@colordx/gpu": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.2.1.tgz",
-      "integrity": "sha512-rq5kURztFXqZ9jveztVsKmQWRnpnPvJ5cCbLuQdOoJtbeyGMXK20guVIhouTnfIHclu4QslXPekviMgdALq4rQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.0.tgz",
+      "integrity": "sha512-5uDoUezXcQ5zZq1wyoiaNOs7gYmzbW8klXlPaD6rHsQ80c4JIUoQE/SumuxuglqbKbKhEOGCw4OcEnu1lR9Tig==",
       "license": "MIT"
     },
     "node_modules/@ctrl/tinycolor": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^4.3.8",
         "@astrojs/starlight": "^0.36.1",
-        "@colordx/gpu": "^0.5.2",
+        "@colordx/gpu": "^0.6.0",
         "@preact/signals-core": "^1.6.0",
         "astro": "^5.6.1",
         "colorjs.io": "^0.6.1",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@colordx/gpu": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.2.tgz",
-      "integrity": "sha512-cvKy4boJ3X34oKIieJM1wZFonYfiY8vbOUx+3561Ef8iLjTkOK4n/g+1122FvVOtWTpdgA81FL6ukAHktQxGZg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.6.0.tgz",
+      "integrity": "sha512-hB6tIgU34TmwXr9VCRBfld3TTsCFobhyNer3rZdwWPGOwiJvzfe0H6yuAELExnJEOA0+w9nBAxJ+KhMoCMUV5g==",
       "license": "MIT"
     },
     "node_modules/@ctrl/tinycolor": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^4.3.8",
         "@astrojs/starlight": "^0.36.1",
-        "@colordx/gpu": "^0.5.0",
+        "@colordx/gpu": "^0.5.2",
         "@preact/signals-core": "^1.6.0",
         "astro": "^5.6.1",
         "colorjs.io": "^0.6.1",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@colordx/gpu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.0.tgz",
-      "integrity": "sha512-5uDoUezXcQ5zZq1wyoiaNOs7gYmzbW8klXlPaD6rHsQ80c4JIUoQE/SumuxuglqbKbKhEOGCw4OcEnu1lR9Tig==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.2.tgz",
+      "integrity": "sha512-cvKy4boJ3X34oKIieJM1wZFonYfiY8vbOUx+3561Ef8iLjTkOK4n/g+1122FvVOtWTpdgA81FL6ukAHktQxGZg==",
       "license": "MIT"
     },
     "node_modules/@ctrl/tinycolor": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^4.3.8",
         "@astrojs/starlight": "^0.36.1",
+        "@colordx/gpu": "^0.2.1",
         "@preact/signals-core": "^1.6.0",
         "astro": "^5.6.1",
         "colorjs.io": "^0.6.1",
@@ -229,6 +230,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@colordx/gpu": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.2.1.tgz",
+      "integrity": "sha512-rq5kURztFXqZ9jveztVsKmQWRnpnPvJ5cCbLuQdOoJtbeyGMXK20guVIhouTnfIHclu4QslXPekviMgdALq4rQ==",
+      "license": "MIT"
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "4.2.0",
@@ -1783,7 +1790,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1944,7 +1950,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.15.1.tgz",
       "integrity": "sha512-VM679M1qxOjGo6q3vKYDNDddkALGgMopG93IwbEXd3Buc2xVLuuPj4HNziNugSbPQx5S6UReMp5uzw10EJN81A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.7.4",
@@ -4852,7 +4857,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5324,7 +5328,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6037,7 +6040,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6236,7 +6238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.8",
     "@astrojs/starlight": "^0.36.1",
-    "@colordx/gpu": "^0.2.1",
+    "@colordx/gpu": "^0.5.0",
     "@preact/signals-core": "^1.6.0",
     "astro": "^5.6.1",
     "colorjs.io": "^0.6.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.8",
     "@astrojs/starlight": "^0.36.1",
-    "@colordx/gpu": "^0.5.2",
+    "@colordx/gpu": "^0.6.0",
     "@preact/signals-core": "^1.6.0",
     "astro": "^5.6.1",
     "colorjs.io": "^0.6.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.8",
     "@astrojs/starlight": "^0.36.1",
+    "@colordx/gpu": "^0.2.1",
     "@preact/signals-core": "^1.6.0",
     "astro": "^5.6.1",
     "colorjs.io": "^0.6.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.8",
     "@astrojs/starlight": "^0.36.1",
-    "@colordx/gpu": "^0.5.0",
+    "@colordx/gpu": "^0.5.2",
     "@preact/signals-core": "^1.6.0",
     "astro": "^5.6.1",
     "colorjs.io": "^0.6.1",

--- a/docs/src/components/OklchGpuComparison.astro
+++ b/docs/src/components/OklchGpuComparison.astro
@@ -53,7 +53,7 @@
   <pre class="gpu-cmp-bench" data-readout="bench" hidden></pre>
   <figcaption>
     All three now render the same slice: chroma→x stretched to the P3 boundary,
-    lightness→y. Arm C uses <code>@colordx/gpu</code> 0.5.0 with
+    lightness→y. Arm C uses <code>@colordx/gpu</code> 0.6.0 with
     <code>transpose</code> for the orientation and <code>math.maxChromaLUT()</code>
     for the stretch — so it should track Arm B (both GPU) closely. Any residual
     difference is the library's parity-tested math vs. the hand-written shader.
@@ -388,7 +388,7 @@ void main(){
         `benchmark · median of ${N} renders @ ${canvasB.width}×${canvasB.height} (DPR ${DPR})\n` +
         `A current (cpu compute, ¼-res ${Math.round(canvasA.width/4)}×${Math.round(canvasA.height/4)}): ${median(aTimes).toFixed(2)} ms\n` +
         `B custom shader (paint + GPU finish):              ${median(bTimes).toFixed(2)} ms\n` +
-        `C @colordx/gpu 0.5.2 (LUT + paint + GPU finish):   ${median(cTimes).toFixed(2)} ms`
+        `C @colordx/gpu 0.6.0 (LUT + paint + GPU finish):   ${median(cTimes).toFixed(2)} ms`
     })
 
     envRead.textContent =

--- a/docs/src/components/OklchGpuComparison.astro
+++ b/docs/src/components/OklchGpuComparison.astro
@@ -1,0 +1,423 @@
+---
+// OKLCH hue-slice rendered three ways, side by side, for the
+// "colordx-gpu" exploration (https://dkryaklin.com/blog/colordx-gpu):
+//   A — current: colorjs.io in a worker, quarter-res, upscaled, polyline border
+//   B — custom WebGL2 fragment shader (this component's conventions)
+//   C — @colordx/gpu createChartRenderer (the library, as-is)
+// Shared hue control + auto-sweep stress test + a benchmark button.
+---
+
+<figure class="gpu-cmp">
+  <div class="gpu-cmp-controls">
+    <label>
+      hue <span data-readout="hue">0</span>°
+      <input type="range" min="0" max="360" step="0.1" value="0" data-control="hue" />
+    </label>
+    <button type="button" data-control="sweep">▶ auto-sweep</button>
+    <button type="button" data-control="bench">benchmark (40×)</button>
+  </div>
+
+  <div class="gpu-cmp-grid">
+    <div class="gpu-cmp-cell">
+      <h4>A · current <small>colorjs + worker, ¼-res</small></h4>
+      <canvas data-arm="a" class="gpu-cmp-canvas"></canvas>
+      <dl class="gpu-cmp-stats">
+        <div><dt>backing</dt><dd data-stat="a-res">—</dd></div>
+        <div><dt>update</dt><dd data-stat="a-ms">—</dd></div>
+        <div><dt>throughput</dt><dd data-stat="a-fps">—</dd></div>
+      </dl>
+    </div>
+
+    <div class="gpu-cmp-cell">
+      <h4>B · custom shader <small>WebGL2, full-res</small></h4>
+      <canvas data-arm="b" class="gpu-cmp-canvas"></canvas>
+      <dl class="gpu-cmp-stats">
+        <div><dt>backing</dt><dd data-stat="b-res">—</dd></div>
+        <div><dt>update</dt><dd data-stat="b-ms">—</dd></div>
+        <div><dt>throughput</dt><dd data-stat="b-fps">—</dd></div>
+      </dl>
+    </div>
+
+    <div class="gpu-cmp-cell">
+      <h4>C · @colordx/gpu <small>library, full-res</small></h4>
+      <canvas data-arm="c" class="gpu-cmp-canvas"></canvas>
+      <dl class="gpu-cmp-stats">
+        <div><dt>backing</dt><dd data-stat="c-res">—</dd></div>
+        <div><dt>update</dt><dd data-stat="c-ms">—</dd></div>
+        <div><dt>throughput</dt><dd data-stat="c-fps">—</dd></div>
+      </dl>
+    </div>
+  </div>
+
+  <p class="gpu-cmp-note" data-readout="env">—</p>
+  <pre class="gpu-cmp-bench" data-readout="bench" hidden></pre>
+  <figcaption>
+    Arm C renders the library's <code>'cl'</code> plane (lightness→x, chroma→y) in
+    absolute coordinates; Arms A &amp; B render this component's slice
+    (chroma→x stretched to the P3 boundary, lightness→y). Orientation and
+    stretch differences are expected — see the report below.
+  </figcaption>
+</figure>
+
+<script>
+  import { createChartRenderer } from '@colordx/gpu'
+  import CpuWorker from './cpu-oklch.worker.ts?worker'
+
+  // ── shared OKLCH math (colordx constants; no color lib) ───────────────────
+  // OKLCH → linear sRGB, used by Arm B's stretch LUT (kept lib-free on purpose)
+  function oklchToLinearSrgb(L: number, C: number, hDeg: number): [number, number, number] {
+    const h = (hDeg * Math.PI) / 180
+    const a = C * Math.cos(h)
+    const b = C * Math.sin(h)
+    const l_ = L + 0.3963377774 * a + 0.2158037573 * b
+    const m_ = L - 0.1055613458 * a - 0.0638541728 * b
+    const s_ = L - 0.0894841775 * a - 1.291485548 * b
+    const l3 = l_ ** 3, m3 = m_ ** 3, s3 = s_ ** 3
+    return [
+      4.0767416613 * l3 - 3.3077115904 * m3 + 0.2309699287 * s3,
+      -1.2684380041 * l3 + 2.6097574007 * m3 - 0.3413193963 * s3,
+      -0.0041960865 * l3 - 0.7034186145 * m3 + 1.7076147009 * s3,
+    ]
+  }
+  function inP3(L: number, C: number, h: number): boolean {
+    const [r, g, b] = oklchToLinearSrgb(L, C, h)
+    // linear sRGB → linear P3 (SRGB_TO_P3, row-major)
+    const pr = 0.8224619687 * r + 0.1775380313 * g
+    const pg = 0.0331941989 * r + 0.9668058011 * g
+    const pb = 0.0170826307 * r + 0.0723974407 * g + 0.9105199286 * b
+    const e = 1e-4
+    return pr >= -e && pr <= 1 + e && pg >= -e && pg <= 1 + e && pb >= -e && pb <= 1 + e
+  }
+  function chromaLUT(hue: number, size = 128): Float32Array {
+    const lut = new Float32Array(size)
+    for (let i = 0; i < size; i++) {
+      const L = i / (size - 1)
+      if (!inP3(L, 0, hue)) { lut[i] = 0; continue }
+      let lo = 0, hi = 0.5
+      for (let j = 0; j < 16; j++) {
+        const mid = (lo + hi) / 2
+        if (inP3(L, mid, hue)) lo = mid; else hi = mid
+      }
+      lut[i] = lo
+    }
+    return lut
+  }
+
+  // ── env / dpr ─────────────────────────────────────────────────────────────
+  const DPR = Math.min(window.devicePixelRatio || 1, 2)
+  function supportsP3Canvas(): boolean {
+    try {
+      const c = document.createElement('canvas')
+      const ctx = c.getContext('2d', { colorSpace: 'display-p3' } as any)
+      return (ctx as any)?.getContextAttributes?.()?.colorSpace === 'display-p3'
+    } catch { return false }
+  }
+  const SUPPORTS_P3 = supportsP3Canvas()
+
+  // ── Arm B: custom WebGL2 shader ────────────────────────────────────────────
+  const VERT = `#version 300 es
+void main(){ vec2 p = vec2(gl_VertexID==1?3.0:-1.0, gl_VertexID==2?3.0:-1.0); gl_Position = vec4(p,0.,1.); }`
+  const FRAG = `#version 300 es
+precision highp float;
+out vec4 frag;
+uniform vec2 u_res;
+uniform float u_hue;
+uniform float u_lut[128];
+uniform bool u_p3Out;
+uniform vec4 u_border;
+uniform float u_borderWidth;
+const float GAP = 1e-7;
+vec3 toLinearSrgb(float L,float C,float h){
+  float hr=radians(h); float a=C*cos(hr); float b=C*sin(hr);
+  float l_=L+0.3963377774*a+0.2158037573*b;
+  float m_=L-0.1055613458*a-0.0638541728*b;
+  float s_=L-0.0894841775*a-1.291485548*b;
+  float l3=l_*l_*l_, m3=m_*m_*m_, s3=s_*s_*s_;
+  return vec3(
+     4.0767416613*l3-3.3077115904*m3+0.2309699287*s3,
+    -1.2684380041*l3+2.6097574007*m3-0.3413193963*s3,
+    -0.0041960865*l3-0.7034186145*m3+1.7076147009*s3);
+}
+vec3 toLinearP3(vec3 c){
+  return vec3(
+    0.8224619687*c.r+0.1775380313*c.g,
+    0.0331941989*c.r+0.9668058011*c.g,
+    0.0170826307*c.r+0.0723974407*c.g+0.9105199286*c.b);
+}
+vec3 srgbEncode(vec3 c){ return mix(12.92*c, 1.055*pow(c,vec3(1.0/2.4))-0.055, step(0.0031308,c)); }
+float overflow(vec3 c){ vec3 d=max(c-1.0,-c); return max(d.r,max(d.g,d.b)); }
+float lut(float t){
+  float fi=clamp(t,0.0,1.0)*127.0; int lo=int(floor(fi)); int hi=min(lo+1,127);
+  return mix(u_lut[lo],u_lut[hi], fi-float(lo));
+}
+float contour(float field){
+  float px=max(length(vec2(dFdx(field),dFdy(field))),1e-12);
+  return step(abs(field)/px, 0.5*u_borderWidth);
+}
+void main(){
+  vec2 uv = gl_FragCoord.xy / u_res;   // x→0..1, y bottom-up = lightness 0..1
+  float L = uv.y;
+  float C = uv.x * lut(L);             // chroma stretched per row to P3 edge
+  vec3 lin = toLinearSrgb(L,C,u_hue);
+  vec3 linP3 = toLinearP3(lin);
+  bool inP = overflow(linP3) <= GAP;
+  vec4 col = vec4(0.0);
+  if(inP){
+    vec3 enc = u_p3Out ? srgbEncode(clamp(linP3,0.0,1.0)) : srgbEncode(clamp(lin,0.0,1.0));
+    enc = floor(enc*255.0+1e-3)/255.0;
+    col = vec4(enc,1.0);
+    float cov = contour(overflow(lin)); // sRGB boundary, analytic
+    float a = cov*u_border.a;
+    col = vec4(mix(col.rgb,u_border.rgb,a), max(col.a,a));
+  }
+  frag = vec4(col.rgb*col.a, col.a);
+}`
+
+  function makeArmB(canvas: HTMLCanvasElement) {
+    const gl = canvas.getContext('webgl2', {
+      alpha: true, antialias: false, depth: false, stencil: false, premultipliedAlpha: true,
+    })
+    if (!gl) return null
+    gl.disable(gl.DITHER)
+    const compile = (type: number, src: string) => {
+      const s = gl.createShader(type)!
+      gl.shaderSource(s, src); gl.compileShader(s)
+      if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(s) || 'shader')
+      return s
+    }
+    const prog = gl.createProgram()!
+    gl.attachShader(prog, compile(gl.VERTEX_SHADER, VERT))
+    gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, FRAG))
+    gl.linkProgram(prog)
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(prog) || 'link')
+    gl.useProgram(prog)
+    const u = (n: string) => gl.getUniformLocation(prog, n)
+    const loc = {
+      res: u('u_res'), hue: u('u_hue'), lut: u('u_lut'), p3Out: u('u_p3Out'),
+      border: u('u_border'), borderWidth: u('u_borderWidth'),
+    }
+    let lastHue = NaN
+    return {
+      canvas,
+      paint(hue: number) {
+        if ('drawingBufferColorSpace' in gl) {
+          try { (gl as any).drawingBufferColorSpace = SUPPORTS_P3 ? 'display-p3' : 'srgb' } catch {}
+        }
+        if (hue !== lastHue) { gl.uniform1fv(loc.lut, chromaLUT(hue)); lastHue = hue }
+        gl.viewport(0, 0, canvas.width, canvas.height)
+        gl.clearColor(0, 0, 0, 0); gl.clear(gl.COLOR_BUFFER_BIT)
+        gl.uniform2f(loc.res, canvas.width, canvas.height)
+        gl.uniform1f(loc.hue, hue)
+        gl.uniform1i(loc.p3Out, SUPPORTS_P3 ? 1 : 0)
+        gl.uniform4f(loc.border, 1, 1, 1, 0.7)
+        gl.uniform1f(loc.borderWidth, 1.5 * DPR)
+        gl.drawArrays(gl.TRIANGLES, 0, 3)
+      },
+      finish() { gl.finish() },
+    }
+  }
+
+  // ── wiring ──────────────────────────────────────────────────────────────────
+  function init(root: HTMLElement) {
+    const $ = <T extends Element>(s: string) => root.querySelector(s) as T
+    const canvasA = $('[data-arm="a"]') as HTMLCanvasElement
+    const canvasB = $('[data-arm="b"]') as HTMLCanvasElement
+    const canvasC = $('[data-arm="c"]') as HTMLCanvasElement
+    const hueInput = $('[data-control="hue"]') as HTMLInputElement
+    const hueRead = $('[data-readout="hue"]') as HTMLElement
+    const sweepBtn = $('[data-control="sweep"]') as HTMLButtonElement
+    const benchBtn = $('[data-control="bench"]') as HTMLButtonElement
+    const envRead = $('[data-readout="env"]') as HTMLElement
+    const benchRead = $('[data-readout="bench"]') as HTMLElement
+    const stat = (k: string) => $(`[data-stat="${k}"]`) as HTMLElement
+
+    // size canvases to their CSS box × DPR
+    function size(canvas: HTMLCanvasElement) {
+      const w = Math.round((canvas.clientWidth || 280) * DPR)
+      const h = Math.round((canvas.clientHeight || 180) * DPR)
+      if (canvas.width !== w || canvas.height !== h) { canvas.width = w; canvas.height = h }
+      return { w, h }
+    }
+
+    // Arm A — colorjs worker, quarter-res, upscale + polyline (the current path)
+    const ctxA = canvasA.getContext('2d', { colorSpace: SUPPORTS_P3 ? 'display-p3' : 'srgb' } as any)!
+    const worker = new CpuWorker()
+    let aSeq = 0, aPending: number | null = null, aBusy = false, aSentAt = 0
+    let off: HTMLCanvasElement | null = null
+    worker.onmessage = (e: MessageEvent) => {
+      const r = e.data
+      const rtt = performance.now() - aSentAt
+      const px = new Uint8ClampedArray(r.pixels)
+      if (!off) off = document.createElement('canvas')
+      off.width = r.W; off.height = r.H
+      const oc = off.getContext('2d', { colorSpace: SUPPORTS_P3 ? 'display-p3' : 'srgb' } as any)!
+      oc.putImageData(new ImageData(px, r.W, r.H), 0, 0)
+      canvasA.width = r.backingW; canvasA.height = r.backingH
+      ctxA.imageSmoothingEnabled = true
+      ctxA.drawImage(off, 0, 0, r.backingW, r.backingH)
+      ctxA.strokeStyle = 'rgba(255,255,255,0.7)'
+      ctxA.lineWidth = 1.5 * DPR
+      ctxA.beginPath()
+      r.boundary.forEach((p: any, i: number) => (i ? ctxA.lineTo(p.x, p.y) : ctxA.moveTo(p.x, p.y)))
+      ctxA.stroke()
+      stat('a-res').textContent = `${r.backingW}×${r.backingH}`
+      stat('a-ms').textContent = `${r.ms.toFixed(1)} ms cpu · ${rtt.toFixed(1)} ms rtt`
+      aFps.tick()
+      aBusy = false
+      if (aPending != null) { const h = aPending; aPending = null; sendA(h) }
+    }
+    function sendA(hue: number) {
+      const { w, h } = size(canvasA)
+      if (aBusy) { aPending = hue; return }
+      aBusy = true; aSentAt = performance.now()
+      worker.postMessage({ id: ++aSeq, hue, cssW: w / DPR, cssH: h / DPR, dpr: DPR, supportsP3: SUPPORTS_P3 })
+    }
+
+    const armB = makeArmB(canvasB)
+    const armC = createChartRenderer(canvasC, { model: 'oklch' })
+
+    function paintB(hue: number) {
+      if (!armB) return
+      size(canvasB)
+      const t = performance.now(); armB.paint(hue); armB.finish()
+      stat('b-ms').textContent = `${(performance.now() - t).toFixed(2)} ms`
+      stat('b-res').textContent = `${canvasB.width}×${canvasB.height}`
+      bFps.tick()
+    }
+    function paintC(hue: number) {
+      if (!armC) return
+      size(canvasC)
+      const t = performance.now()
+      armC.paint({
+        plane: 'cl', value: hue, xMax: 1, yMax: 0.4,
+        showP3: true, showRec2020: true,
+        borderP3: [1, 1, 1, 0.7], borderRec2020: [1, 1, 1, 0.4],
+        borderWidth: 1.5 * DPR, p3Output: SUPPORTS_P3,
+      })
+      stat('c-ms').textContent = `${(performance.now() - t).toFixed(2)} ms issue`
+      stat('c-res').textContent = `${canvasC.width}×${canvasC.height}`
+      cFps.tick()
+    }
+
+    // rolling fps meters
+    function meter(el: HTMLElement) {
+      let n = 0, t0 = performance.now()
+      return {
+        tick() {
+          n++
+          const dt = performance.now() - t0
+          if (dt >= 500) { el.textContent = `${(n / (dt / 1000)).toFixed(0)} /s`; n = 0; t0 = performance.now() }
+        },
+        reset() { n = 0; t0 = performance.now(); el.textContent = '—' },
+      }
+    }
+    const aFps = meter(stat('a-fps')), bFps = meter(stat('b-fps')), cFps = meter(stat('c-fps'))
+
+    function renderAll(hue: number) { sendA(hue); paintB(hue); paintC(hue) }
+
+    // hue control
+    function setHue(hue: number) {
+      hueInput.value = String(hue)
+      hueRead.textContent = hue.toFixed(0)
+      renderAll(hue)
+    }
+    hueInput.addEventListener('input', () => setHue(parseFloat(hueInput.value)))
+
+    // auto-sweep
+    let sweeping = false, raf = 0
+    sweepBtn.addEventListener('click', () => {
+      sweeping = !sweeping
+      sweepBtn.textContent = sweeping ? '⏸ stop' : '▶ auto-sweep'
+      ;[aFps, bFps, cFps].forEach((m) => m.reset())
+      if (sweeping) {
+        const loop = () => {
+          if (!sweeping) return
+          let h = parseFloat(hueInput.value) + 1.5
+          if (h > 360) h -= 360
+          setHue(h)
+          raf = requestAnimationFrame(loop)
+        }
+        raf = requestAnimationFrame(loop)
+      } else cancelAnimationFrame(raf)
+    })
+
+    // benchmark — median ms over N renders at the current resolution
+    benchBtn.addEventListener('click', async () => {
+      const N = 40
+      benchRead.hidden = false
+      benchRead.textContent = 'running…'
+      const median = (xs: number[]) => xs.sort((a, b) => a - b)[Math.floor(xs.length / 2)]
+
+      // Arm A: worker compute ms (round-trip), serialized
+      const aTimes: number[] = []
+      for (let i = 0; i < N; i++) {
+        const hue = (i * 9) % 360
+        const ms = await new Promise<number>((res) => {
+          const onmsg = (e: MessageEvent) => { worker.removeEventListener('message', onmsg); res(e.data.ms) }
+          worker.addEventListener('message', onmsg)
+          const { w, h } = size(canvasA)
+          worker.postMessage({ id: -1, hue, cssW: w / DPR, cssH: h / DPR, dpr: DPR, supportsP3: SUPPORTS_P3 })
+        })
+        aTimes.push(ms)
+      }
+      // Arms B & C: paint + (B) GPU finish
+      const bTimes: number[] = [], cTimes: number[] = []
+      for (let i = 0; i < N; i++) {
+        const hue = (i * 9) % 360
+        let t = performance.now(); armB?.paint(hue); armB?.finish(); bTimes.push(performance.now() - t)
+        t = performance.now()
+        armC?.paint({ plane: 'cl', value: hue, xMax: 1, yMax: 0.4, showP3: true, showRec2020: true, borderP3: [1,1,1,0.7], borderRec2020: [1,1,1,0.4], borderWidth: 1.5 * DPR, p3Output: SUPPORTS_P3 })
+        cTimes.push(performance.now() - t)
+      }
+      benchRead.textContent =
+        `benchmark · median of ${N} renders @ ${canvasB.width}×${canvasB.height} (DPR ${DPR})\n` +
+        `A current (cpu compute, ¼-res ${Math.round(canvasA.width/4)}×${Math.round(canvasA.height/4)}): ${median(aTimes).toFixed(2)} ms\n` +
+        `B custom shader (paint + GPU finish):              ${median(bTimes).toFixed(2)} ms\n` +
+        `C @colordx/gpu (paint issue, GPU async):           ${median(cTimes).toFixed(3)} ms`
+    })
+
+    envRead.textContent =
+      `device-pixel-ratio ${DPR} · display-p3 canvas ${SUPPORTS_P3 ? 'yes' : 'no'} · ` +
+      `WebGL2 ${armB ? 'yes' : 'no'} · @colordx/gpu ${armC ? 'ready' : 'unavailable'}`
+
+    // defer first paint until layout has given the canvases a real size
+    requestAnimationFrame(() => setHue(0))
+  }
+
+  function boot() {
+    document.querySelectorAll<HTMLElement>('.gpu-cmp').forEach((el) => {
+      if ((el as any)._booted) return
+      ;(el as any)._booted = true
+      init(el)
+    })
+  }
+  document.addEventListener('DOMContentLoaded', boot)
+  document.addEventListener('astro:page-load', boot)
+</script>
+
+<style>
+  .gpu-cmp { margin: 1.5rem 0; }
+  .gpu-cmp-controls { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; margin-bottom: 1rem; }
+  .gpu-cmp-controls label { display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; }
+  .gpu-cmp-controls input[type='range'] { width: 180px; }
+  .gpu-cmp-controls button {
+    font: inherit; font-size: 0.8rem; padding: 0.3rem 0.7rem; cursor: pointer;
+    border: 1px solid var(--sl-color-gray-4); border-radius: 6px; background: var(--sl-color-gray-6);
+  }
+  .gpu-cmp-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+  @media (max-width: 860px) { .gpu-cmp-grid { grid-template-columns: 1fr; } }
+  .gpu-cmp-cell h4 { margin: 0 0 0.4rem; font-size: 0.85rem; display: flex; justify-content: space-between; align-items: baseline; gap: 0.5rem; }
+  .gpu-cmp-cell h4 small { font-weight: 400; color: var(--sl-color-gray-3); font-size: 0.7rem; }
+  .gpu-cmp-canvas {
+    width: 100%; aspect-ratio: 16 / 10; display: block; border-radius: 8px;
+    background: repeating-conic-gradient(#808080 0% 25%, #999 0% 50%) 50% / 16px 16px;
+    border: 1px solid var(--sl-color-gray-5);
+  }
+  .gpu-cmp-stats { display: flex; gap: 0.9rem; margin: 0.5rem 0 0; font-size: 0.72rem; }
+  .gpu-cmp-stats div { display: flex; flex-direction: column; }
+  .gpu-cmp-stats dt { color: var(--sl-color-gray-3); }
+  .gpu-cmp-stats dd { margin: 0; font-variant-numeric: tabular-nums; }
+  .gpu-cmp-note { font-size: 0.72rem; color: var(--sl-color-gray-3); margin: 0.9rem 0 0; }
+  .gpu-cmp-bench { font-size: 0.72rem; padding: 0.7rem; border-radius: 6px; background: var(--sl-color-gray-6); white-space: pre; overflow-x: auto; }
+  .gpu-cmp figcaption { font-size: 0.72rem; color: var(--sl-color-gray-3); margin-top: 0.6rem; line-height: 1.5; }
+</style>

--- a/docs/src/components/OklchGpuComparison.astro
+++ b/docs/src/components/OklchGpuComparison.astro
@@ -52,15 +52,16 @@
   <p class="gpu-cmp-note" data-readout="env">—</p>
   <pre class="gpu-cmp-bench" data-readout="bench" hidden></pre>
   <figcaption>
-    Arm C renders the library's <code>'cl'</code> plane (lightness→x, chroma→y) in
-    absolute coordinates; Arms A &amp; B render this component's slice
-    (chroma→x stretched to the P3 boundary, lightness→y). Orientation and
-    stretch differences are expected — see the report below.
+    All three now render the same slice: chroma→x stretched to the P3 boundary,
+    lightness→y. Arm C uses <code>@colordx/gpu</code> 0.5.0 with
+    <code>transpose</code> for the orientation and <code>math.maxChromaLUT()</code>
+    for the stretch — so it should track Arm B (both GPU) closely. Any residual
+    difference is the library's parity-tested math vs. the hand-written shader.
   </figcaption>
 </figure>
 
 <script>
-  import { createChartRenderer } from '@colordx/gpu'
+  import { createChartRenderer, math } from '@colordx/gpu'
   import CpuWorker from './cpu-oklch.worker.ts?worker'
 
   // ── shared OKLCH math (colordx constants; no color lib) ───────────────────
@@ -284,17 +285,33 @@ void main(){
       stat('b-res').textContent = `${canvasB.width}×${canvasB.height}`
       bFps.tick()
     }
+    // Build the library paint options for our slice: transpose so chroma→x /
+    // lightness→y (matches A & B), and a per-row chroma stretch LUT to P3
+    // (math.maxChromaLUT — the same binary search the CPU arm runs). The LUT is
+    // rebuilt only on hue change and counted in the timed region, like A & B.
+    let lutHueC = NaN, lutC: Float32Array | null = null
+    function paintOptsC(hue: number) {
+      if (hue !== lutHueC) {
+        lutC = (math as any).maxChromaLUT({ model: 'oklch', hue, gamut: 'p3' })
+        lutHueC = hue
+      }
+      return {
+        plane: 'cl' as const, value: hue, xMax: 1, yMax: 0.4,
+        transpose: true, chromaLUT: lutC!,
+        gamuts: [
+          { space: 'p3' as const, fill: true },
+          { space: 'srgb' as const, border: [1, 1, 1, 0.7] as [number, number, number, number] },
+        ],
+        borderWidth: 1.5 * DPR, p3Output: SUPPORTS_P3,
+      }
+    }
     function paintC(hue: number) {
       if (!armC) return
       size(canvasC)
       const t = performance.now()
-      armC.paint({
-        plane: 'cl', value: hue, xMax: 1, yMax: 0.4,
-        showP3: true, showRec2020: true,
-        borderP3: [1, 1, 1, 0.7], borderRec2020: [1, 1, 1, 0.4],
-        borderWidth: 1.5 * DPR, p3Output: SUPPORTS_P3,
-      })
-      stat('c-ms').textContent = `${(performance.now() - t).toFixed(2)} ms issue`
+      armC.paint(paintOptsC(hue))
+      armC.gl.finish() // 0.5.0 exposes gl, so C can be timed like B
+      stat('c-ms').textContent = `${(performance.now() - t).toFixed(2)} ms`
       stat('c-res').textContent = `${canvasC.width}×${canvasC.height}`
       cFps.tick()
     }
@@ -366,14 +383,14 @@ void main(){
         const hue = (i * 9) % 360
         let t = performance.now(); armB?.paint(hue); armB?.finish(); bTimes.push(performance.now() - t)
         t = performance.now()
-        armC?.paint({ plane: 'cl', value: hue, xMax: 1, yMax: 0.4, showP3: true, showRec2020: true, borderP3: [1,1,1,0.7], borderRec2020: [1,1,1,0.4], borderWidth: 1.5 * DPR, p3Output: SUPPORTS_P3 })
+        if (armC) { armC.paint(paintOptsC(hue)); armC.gl.finish() }
         cTimes.push(performance.now() - t)
       }
       benchRead.textContent =
         `benchmark · median of ${N} renders @ ${canvasB.width}×${canvasB.height} (DPR ${DPR})\n` +
         `A current (cpu compute, ¼-res ${Math.round(canvasA.width/4)}×${Math.round(canvasA.height/4)}): ${median(aTimes).toFixed(2)} ms\n` +
         `B custom shader (paint + GPU finish):              ${median(bTimes).toFixed(2)} ms\n` +
-        `C @colordx/gpu (paint issue, GPU async):           ${median(cTimes).toFixed(3)} ms`
+        `C @colordx/gpu 0.5.0 (LUT + paint + GPU finish):   ${median(cTimes).toFixed(2)} ms`
     })
 
     envRead.textContent =

--- a/docs/src/components/OklchGpuComparison.astro
+++ b/docs/src/components/OklchGpuComparison.astro
@@ -127,7 +127,6 @@ uniform float u_lut[128];
 uniform bool u_p3Out;
 uniform vec4 u_border;
 uniform float u_borderWidth;
-const float GAP = 1e-7;
 vec3 toLinearSrgb(float L,float C,float h){
   float hr=radians(h); float a=C*cos(hr); float b=C*sin(hr);
   float l_=L+0.3963377774*a+0.2158037573*b;
@@ -161,17 +160,16 @@ void main(){
   float C = uv.x * lut(L);             // chroma stretched per row to P3 edge
   vec3 lin = toLinearSrgb(L,C,u_hue);
   vec3 linP3 = toLinearP3(lin);
-  bool inP = overflow(linP3) <= GAP;
-  vec4 col = vec4(0.0);
-  if(inP){
-    vec3 enc = u_p3Out ? srgbEncode(clamp(linP3,0.0,1.0)) : srgbEncode(clamp(lin,0.0,1.0));
-    enc = floor(enc*255.0+1e-3)/255.0;
-    col = vec4(enc,1.0);
-    float cov = contour(overflow(lin)); // sRGB boundary, analytic
-    float a = cov*u_border.a;
-    col = vec4(mix(col.rgb,u_border.rgb,a), max(col.a,a));
-  }
-  frag = vec4(col.rgb*col.a, col.a);
+  // The stretched slice spans exactly to the P3 edge, so every column is in
+  // gamut by construction — fill solid (clamped) instead of dropping the rows
+  // where the JS LUT and the shader's gamut test disagree by a hair at low
+  // lightness (the transparent "wedge" along the bottom).
+  vec3 enc = u_p3Out ? srgbEncode(clamp(linP3,0.0,1.0)) : srgbEncode(clamp(lin,0.0,1.0));
+  enc = floor(enc*255.0+1e-3)/255.0;
+  vec4 col = vec4(enc,1.0);
+  float cov = contour(overflow(lin)); // sRGB boundary, analytic
+  col = vec4(mix(col.rgb,u_border.rgb,cov*u_border.a), 1.0);
+  frag = vec4(col.rgb, 1.0);
 }`
 
   function makeArmB(canvas: HTMLCanvasElement) {
@@ -292,7 +290,7 @@ void main(){
     let lutHueC = NaN, lutC: Float32Array | null = null
     function paintOptsC(hue: number) {
       if (hue !== lutHueC) {
-        lutC = (math as any).maxChromaLUT({ model: 'oklch', hue, gamut: 'p3' })
+        lutC = math.maxChromaLUT({ model: 'oklch', hue, gamut: 'p3' })
         lutHueC = hue
       }
       return {
@@ -390,7 +388,7 @@ void main(){
         `benchmark · median of ${N} renders @ ${canvasB.width}×${canvasB.height} (DPR ${DPR})\n` +
         `A current (cpu compute, ¼-res ${Math.round(canvasA.width/4)}×${Math.round(canvasA.height/4)}): ${median(aTimes).toFixed(2)} ms\n` +
         `B custom shader (paint + GPU finish):              ${median(bTimes).toFixed(2)} ms\n` +
-        `C @colordx/gpu 0.5.0 (LUT + paint + GPU finish):   ${median(cTimes).toFixed(2)} ms`
+        `C @colordx/gpu 0.5.2 (LUT + paint + GPU finish):   ${median(cTimes).toFixed(2)} ms`
     })
 
     envRead.textContent =

--- a/docs/src/components/cpu-oklch.worker.ts
+++ b/docs/src/components/cpu-oklch.worker.ts
@@ -1,0 +1,112 @@
+// Arm A — the CURRENT approach, isolated to OKLCH for the comparison.
+//
+// This is a faithful, trimmed copy of src/area-picker.worker.ts's OKLCH path:
+// colorjs.io per-pixel conversion, rendered at quarter backing resolution,
+// chroma stretched per-lightness-row to the P3 gamut, with the sRGB gamut
+// boundary returned as a sampled polyline. The main thread upscales the
+// quarter-res pixels with drawImage() and strokes the polyline — exactly the
+// pipeline the live component ships today.
+
+import * as colorjs from 'colorjs.io/fn'
+
+colorjs.ColorSpace.register(colorjs.sRGB)
+colorjs.ColorSpace.register(colorjs.sRGB_Linear)
+colorjs.ColorSpace.register(colorjs.OKLab)
+colorjs.ColorSpace.register(colorjs.OKLCH)
+colorjs.ColorSpace.register(colorjs.P3)
+colorjs.ColorSpace.register(colorjs.XYZ_D65)
+colorjs.ColorSpace.register(colorjs.XYZ_D50)
+
+const X_MAX = 0.37 // chroma axis max, matches AREA_CONFIGS.oklch
+const STRETCH = 'p3' // oklch slice stretches chroma to fill the P3 boundary
+
+function isInGamut(coords: [number, number, number], gamut: string): boolean {
+  const converted = colorjs.to({ spaceId: 'oklch', coords, alpha: 1 }, gamut)
+  return colorjs.inGamut({ spaceId: gamut, coords: converted.coords, alpha: null })
+}
+
+function lerpLUT(lut: Float64Array, t: number): number {
+  const n = lut.length - 1
+  const i = Math.max(0, Math.min(n, t * n))
+  const lo = Math.floor(i)
+  const hi = Math.min(lo + 1, n)
+  const f = i - lo
+  return lut[lo]! * (1 - f) + lut[hi]! * f
+}
+
+// max in-gamut chroma per lightness row (the "scaffolding" the CPU needs)
+function computeChromaLUT(hue: number, gamut: string, size: number): Float64Array {
+  const lut = new Float64Array(size)
+  for (let i = 0; i < size; i++) {
+    const L = i / (size - 1)
+    if (!isInGamut([L, 0, hue], gamut)) {
+      lut[i] = 0
+      continue
+    }
+    let lo = 0,
+      hi = 0.5
+    for (let j = 0; j < 16; j++) {
+      const mid = (lo + hi) / 2
+      if (isInGamut([L, mid, hue], gamut)) lo = mid
+      else hi = mid
+    }
+    lut[i] = lo
+  }
+  return lut
+}
+
+self.onmessage = (e: MessageEvent) => {
+  const { id, hue, cssW, cssH, dpr, supportsP3 } = e.data
+  const t0 = performance.now()
+
+  const targetSpace = supportsP3 ? 'p3' : 'srgb'
+  const backingW = Math.round(cssW * dpr)
+  const backingH = Math.round(cssH * dpr)
+  // quarter backing resolution — identical to area-picker.worker.ts
+  const W = Math.round(backingW / 4)
+  const H = Math.round(backingH / 4)
+
+  const chromaLUT = computeChromaLUT(hue, STRETCH, 128)
+
+  const pixels = new Uint8ClampedArray(W * H * 4)
+  for (let y = 0; y < H; y++) {
+    const Y = 1 - y / (H - 1) // lightness, top = 1
+    const maxC = lerpLUT(chromaLUT, Y)
+    for (let x = 0; x < W; x++) {
+      const X = x / (W - 1)
+      const chroma = X * maxC
+      const [r, g, b] = colorjs.to(
+        { spaceId: 'oklch', coords: [Y, chroma, hue], alpha: null },
+        targetSpace
+      ).coords
+      const i = (y * W + x) * 4
+      pixels[i] = Math.round(Math.max(0, Math.min(1, r ?? 0)) * 255)
+      pixels[i + 1] = Math.round(Math.max(0, Math.min(1, g ?? 0)) * 255)
+      pixels[i + 2] = Math.round(Math.max(0, Math.min(1, b ?? 0)) * 255)
+      pixels[i + 3] = 255
+    }
+  }
+
+  // sRGB boundary as a sampled polyline (row-scan + bisection), in backing px
+  const ROWS = 100
+  const boundary: { x: number; y: number }[] = []
+  for (let row = 0; row <= ROWS; row++) {
+    const yNorm = row / ROWS
+    const maxOuter = lerpLUT(chromaLUT, yNorm)
+    if (maxOuter <= 0) continue
+    if (!isInGamut([yNorm, 0, hue], 'srgb')) continue
+    let lo = 0,
+      hi = maxOuter
+    for (let i = 0; i < 10; i++) {
+      const mid = (lo + hi) / 2
+      if (isInGamut([yNorm, mid, hue], 'srgb')) lo = mid
+      else hi = mid
+    }
+    boundary.push({ x: (lo / maxOuter) * backingW, y: (1 - yNorm) * backingH })
+  }
+
+  const ms = performance.now() - t0
+  self.postMessage({ id, pixels: pixels.buffer, W, H, backingW, backingH, boundary, ms }, [
+    pixels.buffer,
+  ] as any)
+}

--- a/docs/src/content/docs/gpu-comparison.mdx
+++ b/docs/src/content/docs/gpu-comparison.mdx
@@ -1,0 +1,104 @@
+---
+title: GPU rendering exploration (prototype)
+description: Comparing the current colorjs worker, a custom WebGL2 shader, and @colordx/gpu for the OKLCH area slice.
+---
+
+import OklchGpuComparison from '../../components/OklchGpuComparison.astro';
+
+:::caution[Prototype]
+This page is an exploration on the `oklch-webgl2-prototype` branch, prompted by
+[“Blazing-fast color manipulation at scale on the GPU”](https://dkryaklin.com/blog/colordx-gpu).
+It is **not** wired into the shipping `<color-input>` component — it renders the
+OKLCH hue slice three independent ways so we can compare them. Nothing here
+changes the component's behavior.
+:::
+
+The area picker is the most expensive thing this component draws. Today it is
+computed **per pixel on the CPU** with colorjs.io, in a Web Worker, at **quarter
+backing resolution**, then upscaled with `drawImage()`; gamut boundaries are
+**sampled polylines**. The article above argues that per-pixel color work belongs
+in a fragment shader. This page tests that claim for our exact slice.
+
+## Try it
+
+<OklchGpuComparison />
+
+Drag the hue, or hit **auto-sweep** to stress every arm continuously and watch
+the throughput counters. **Benchmark** runs 40 renders per arm and reports the
+median. The GPU numbers depend on your hardware and need a real browser — read
+them off the live demo above or the staged Netlify preview.
+
+### Measured CPU baseline (Arm A)
+
+The CPU side is measurable off-browser. Converting OKLCH→Display-P3 with
+colorjs.io (Node v24, M-series laptop, median of 9):
+
+| measurement | value |
+|---|---|
+| per-conversion | **~617 ns** (~1.6M/s) — vs colordx's cited 213 ns |
+| frame @ ¼-res (140×88 ≈ 12k px) | **~7.6 ms** — what ships today |
+| frame @ full-res (560×350 ≈ 196k px) | **~117 ms** (~7 fps) — why CPU full-res is a non-starter |
+
+A fragment shader produces that same full-res frame in well under a millisecond,
+off the main thread — the ~100×+ gap the article describes, reproduced on our
+exact slice. The ¼-res trick keeps Arm A inside a frame budget today, but at the
+cost of the visible upscale blur and a re-render on every hue drag.
+
+## The three approaches
+
+| | A — current | B — custom WebGL2 shader | C — `@colordx/gpu` |
+|---|---|---|---|
+| Where the per-pixel math runs | CPU (colorjs.io) in a worker | GPU fragment shader | GPU fragment shader |
+| Resolution | ¼ backing, upscaled (blurry) | full backing, crisp | full backing, crisp |
+| Gamut boundary | sampled polyline (~100 pts + bisection) | analytic contour in-shader | analytic contour in-shader |
+| Per-frame allocation | 250k–1M short-lived objects | none | none |
+| Color spaces | all (okhsv/oklch/hsl/oklab/lab/hwb) | only what you write GLSL for | OKLCH + CIE LCH only |
+| Slice orientation | chroma→x, lightness→y | chroma→x, lightness→y | lightness→x, chroma→y (`'cl'`) |
+| Chroma stretch-to-gamut | yes (per-row LUT) | yes (per-row LUT) | no (absolute coords) |
+| Gamut boundaries drawn | sRGB/P3/Rec2020/ProPhoto/A98 | whatever you code (sRGB here) | sRGB↔P3 and P3↔Rec2020 |
+| New dependency | none (already shipped) | none (hand-written GLSL) | `@colordx/gpu` (~small) |
+| Maintenance | owned, but slow by design | **you own a parallel GLSL impl** | upstream owns it; less control |
+
+## What the prototype shows
+
+- **Both GPU arms remove the worker round-trip, the quarter-res blur, and the
+  per-pixel allocation.** The slice is crisp at full DPR and fullscreen repaint
+  is effectively free — exactly the article's result.
+- **The CPU arm's cost is real but modest per frame** thanks to the quarter-res
+  trick; its true tax is GC pressure and the round-trip latency during a drag,
+  which shows up as the lower, jittery throughput number under auto-sweep.
+- **A custom shader (B) can reproduce our slice exactly** — same chroma→x /
+  lightness→y orientation and the same per-row chroma stretch (computed once as a
+  128-entry LUT, ~2k conversions per hue change, vs ~250k per frame today).
+- **The library (C) is the least code but the least flexible:** it renders its
+  own plane conventions in absolute coordinates, covers only OKLCH/CIE LCH, and
+  draws only sRGB/P3/Rec2020 boundaries. Adopting it for *all* of our spaces
+  (okhsv, hsl, oklab, lab, hwb) and gamuts (a98rgb, prophoto) is not possible
+  today — it would be an OKLCH/LCH-only fast path alongside the existing CPU one.
+
+## Tradeoffs / recommendation
+
+1. **The technique is clearly worth adopting for the OKLCH/OKLab/LCH slices.**
+   Full-res, no GC hitches, exact boundaries.
+2. **Prefer the custom shader (B) over the library (C) for integration**, because
+   it matches our slice orientation and stretch UX and adds no dependency — at the
+   cost of owning a GLSL implementation that must be parity-tested against
+   colorjs.io (the article's "one constants module → both impls + parity test"
+   discipline applies).
+3. **Keep colorjs.io as the CPU path** for the spaces a shader doesn't cover and
+   as the WebGL2-unavailable fallback. At ~213 ns/color the CPU wins per-call
+   work (parsing, the selected-color readout) where the GPU's fixed latency loses.
+4. **`@colordx/gpu` is the fastest way to validate the idea** (this page uses it
+   live) and a reasonable choice if we ever expose an OKLCH-only "chart" mode, but
+   it is not a drop-in replacement for the multi-space area picker.
+
+### Caveats observed
+
+- Firefox lacks WebGL `display-p3`, so GPU arms clip to sRGB there (gamut
+  classification still correct) — the env line under the demo reports support.
+- A canvas that has handed out a WebGL context can't also give a `2d` context, so
+  the GPU-vs-CPU choice must be made per canvas before first paint.
+- Arm C's "issue" time excludes GPU completion (the library doesn't expose its
+  context for a `finish()`); Arm B's number includes a `gl.finish()`, so B's ms
+  looks larger than C's despite doing the same class of work. Compare the
+  **throughput** counters for an end-to-end read.

--- a/docs/src/content/docs/gpu-comparison.mdx
+++ b/docs/src/content/docs/gpu-comparison.mdx
@@ -13,13 +13,16 @@ OKLCH hue slice three independent ways so we can compare them. Nothing here
 changes the component's behavior.
 :::
 
-:::note[Updated for @colordx/gpu 0.5.0]
+:::note[Updated for @colordx/gpu 0.5.2]
 After the first round, the library's maintainer shipped **0.5.0** closing every
 Arm C gap surfaced here ([colordx-gpu#8](https://github.com/dkryaklin/colordx-gpu/issues/8)):
 `transpose` + `renderer.gl`, `model: 'oklab' | 'lab'`, a98/prophoto gamuts, and a
 per-row chroma stretch via `paint({ chromaLUT })` built by `math.maxChromaLUT()`.
-Arm C below is now wired with all of it, so **all three arms render the same
-slice** — the comparison and recommendation are updated accordingly.
+Then **0.5.1/0.5.2** fixed the boundary line under stretch — an anti-aliased
+coverage ramp so the contour no longer breaks into dashes near gamut cusps, and a
+per-row analytic position for the stretched border so the doubled line is gone —
+plus the `math.d.ts` types. Arm C below is wired with all of it, so **all three
+arms render the same slice** — comparison and recommendation updated accordingly.
 :::
 
 The area picker is the most expensive thing this component draws. Today it is
@@ -55,7 +58,7 @@ cost of the visible upscale blur and a re-render on every hue drag.
 
 ## The three approaches
 
-| | A — current | B — custom WebGL2 shader | C — `@colordx/gpu` 0.5.0 |
+| | A — current | B — custom WebGL2 shader | C — `@colordx/gpu` 0.5.2 |
 |---|---|---|---|
 | Where the per-pixel math runs | CPU (colorjs.io) in a worker | GPU fragment shader | GPU fragment shader |
 | Resolution | ¼ backing, upscaled (blurry) | full backing, crisp | full backing, crisp |
@@ -117,5 +120,7 @@ cost of the visible upscale blur and a re-render on every hue drag.
 - Both GPU arms are now timed with a `gl.finish()` (Arm C via the exposed
   `renderer.gl`), so their benchmark numbers are directly comparable; the
   **throughput** counters remain the best end-to-end read.
-- `@colordx/gpu@0.5.0` ships `math.maxChromaLUT()` but it's missing from the
-  published `math.d.ts`, so this prototype calls it through a small cast.
+- Arm B's stretch uses the same fill-solid trick as the library: the slice spans
+  exactly to the P3 edge, so it fills every column rather than dropping the
+  low-lightness rows where the LUT and the shader's gamut test disagree by a hair
+  (the earlier transparent "wedge" at the bottom).

--- a/docs/src/content/docs/gpu-comparison.mdx
+++ b/docs/src/content/docs/gpu-comparison.mdx
@@ -13,6 +13,15 @@ OKLCH hue slice three independent ways so we can compare them. Nothing here
 changes the component's behavior.
 :::
 
+:::note[Updated for @colordx/gpu 0.5.0]
+After the first round, the library's maintainer shipped **0.5.0** closing every
+Arm C gap surfaced here ([colordx-gpu#8](https://github.com/dkryaklin/colordx-gpu/issues/8)):
+`transpose` + `renderer.gl`, `model: 'oklab' | 'lab'`, a98/prophoto gamuts, and a
+per-row chroma stretch via `paint({ chromaLUT })` built by `math.maxChromaLUT()`.
+Arm C below is now wired with all of it, so **all three arms render the same
+slice** — the comparison and recommendation are updated accordingly.
+:::
+
 The area picker is the most expensive thing this component draws. Today it is
 computed **per pixel on the CPU** with colorjs.io, in a Web Worker, at **quarter
 backing resolution**, then upscaled with `drawImage()`; gamut boundaries are
@@ -46,18 +55,19 @@ cost of the visible upscale blur and a re-render on every hue drag.
 
 ## The three approaches
 
-| | A — current | B — custom WebGL2 shader | C — `@colordx/gpu` |
+| | A — current | B — custom WebGL2 shader | C — `@colordx/gpu` 0.5.0 |
 |---|---|---|---|
 | Where the per-pixel math runs | CPU (colorjs.io) in a worker | GPU fragment shader | GPU fragment shader |
 | Resolution | ¼ backing, upscaled (blurry) | full backing, crisp | full backing, crisp |
 | Gamut boundary | sampled polyline (~100 pts + bisection) | analytic contour in-shader | analytic contour in-shader |
-| Per-frame allocation | 250k–1M short-lived objects | none | none |
-| Color spaces | all (okhsv/oklch/hsl/oklab/lab/hwb) | only what you write GLSL for | OKLCH + CIE LCH only |
-| Slice orientation | chroma→x, lightness→y | chroma→x, lightness→y | lightness→x, chroma→y (`'cl'`) |
-| Chroma stretch-to-gamut | yes (per-row LUT) | yes (per-row LUT) | no (absolute coords) |
-| Gamut boundaries drawn | sRGB/P3/Rec2020/ProPhoto/A98 | whatever you code (sRGB here) | sRGB↔P3 and P3↔Rec2020 |
-| New dependency | none (already shipped) | none (hand-written GLSL) | `@colordx/gpu` (~small) |
-| Maintenance | owned, but slow by design | **you own a parallel GLSL impl** | upstream owns it; less control |
+| Per-frame allocation | 250k–1M short-lived objects | none | none (one small LUT/hue) |
+| Color spaces | all (okhsv/oklch/hsl/oklab/lab/hwb) | only what you write GLSL for | oklch/oklab/lch/lab (wide-gamut planes) |
+| Slice orientation | chroma→x, lightness→y | chroma→x, lightness→y | chroma→x, lightness→y (`transpose`) |
+| Chroma stretch-to-gamut | yes (per-row LUT) | yes (per-row LUT) | yes (`math.maxChromaLUT`) |
+| Gamut boundaries drawn | sRGB/P3/Rec2020/ProPhoto/A98 | whatever you code (sRGB here) | any layer: sRGB/P3/A98/Rec2020/ProPhoto |
+| New dependency | none (already shipped) | none (hand-written GLSL) | `@colordx/gpu` |
+| Parity guarantee | n/a (it *is* colorjs.io) | **you own the drift test** | inherits the lib's parity suite |
+| Maintenance | owned, but slow by design | **you own a parallel GLSL impl** | upstream owns the shader + matrices |
 
 ## What the prototype shows
 
@@ -67,30 +77,36 @@ cost of the visible upscale blur and a re-render on every hue drag.
 - **The CPU arm's cost is real but modest per frame** thanks to the quarter-res
   trick; its true tax is GC pressure and the round-trip latency during a drag,
   which shows up as the lower, jittery throughput number under auto-sweep.
-- **A custom shader (B) can reproduce our slice exactly** — same chroma→x /
-  lightness→y orientation and the same per-row chroma stretch (computed once as a
-  128-entry LUT, ~2k conversions per hue change, vs ~250k per frame today).
-- **The library (C) is the least code but the least flexible:** it renders its
-  own plane conventions in absolute coordinates, covers only OKLCH/CIE LCH, and
-  draws only sRGB/P3/Rec2020 boundaries. Adopting it for *all* of our spaces
-  (okhsv, hsl, oklab, lab, hwb) and gamuts (a98rgb, prophoto) is not possible
-  today — it would be an OKLCH/LCH-only fast path alongside the existing CPU one.
+- **B and C now produce the same slice.** With 0.5.0's `transpose` and
+  `math.maxChromaLUT()`, Arm C matches the hand-written shader's orientation and
+  per-row chroma stretch; on screen they track each other, and the benchmark
+  times them the same way (both `gl.finish()` via the now-exposed `renderer.gl`).
+- **The library covers the wide-gamut planes we care about** — oklch/oklab/lch/lab
+  across srgb/p3/a98/rec2020/prophoto, each gamut an independent fill/border
+  layer. The only spaces it doesn't do are the sRGB-cylindrical family
+  (hsl, hwb, okhsv) — which are cheap and sRGB-only, so leaving them on the CPU
+  path is the right call, not a gap.
+- **The real difference between B and C is ownership.** B is zero-dependency but
+  you maintain the GLSL and a colorjs-parity test forever; C is a dependency but
+  inherits the library's parity suite against `@colordx/core`.
 
 ## Tradeoffs / recommendation
 
-1. **The technique is clearly worth adopting for the OKLCH/OKLab/LCH slices.**
+1. **The technique is clearly worth adopting for the OKLCH/OKLab/LCH/Lab slices.**
    Full-res, no GC hitches, exact boundaries.
-2. **Prefer the custom shader (B) over the library (C) for integration**, because
-   it matches our slice orientation and stretch UX and adds no dependency — at the
-   cost of owning a GLSL implementation that must be parity-tested against
-   colorjs.io (the article's "one constants module → both impls + parity test"
-   discipline applies).
-3. **Keep colorjs.io as the CPU path** for the spaces a shader doesn't cover and
-   as the WebGL2-unavailable fallback. At ~213 ns/color the CPU wins per-call
-   work (parsing, the selected-color readout) where the GPU's fixed latency loses.
-4. **`@colordx/gpu` is the fastest way to validate the idea** (this page uses it
-   live) and a reasonable choice if we ever expose an OKLCH-only "chart" mode, but
-   it is not a drop-in replacement for the multi-space area picker.
+2. **With 0.5.0, `@colordx/gpu` (C) becomes the better integration choice over a
+   hand-written shader (B)** for those wide-gamut planes. It now matches our
+   orientation and stretch, covers the spaces and gamuts we use, and — the
+   deciding factor — lets us inherit its parity suite instead of owning GLSL plus
+   a colorjs-drift test. B stays valuable as a zero-dependency reference and a
+   sanity check, but it's no longer the obvious pick.
+3. **Keep colorjs.io as the CPU path** for the sRGB-cylindrical spaces a shader
+   doesn't cover (hsl/hwb/okhsv) and as the WebGL2-unavailable fallback. Per-call
+   work (parsing, the selected-color readout) is where the GPU's fixed latency
+   loses, so the CPU path earns its keep regardless.
+4. **Shape of an integration:** an OKLCH/OKLab/LCH/Lab GPU fast path in front of
+   the existing CPU painter, chosen per canvas (a canvas can't switch between
+   WebGL and `2d`), with the DOM overlay for the hover/selection marker unchanged.
 
 ### Caveats observed
 
@@ -98,7 +114,8 @@ cost of the visible upscale blur and a re-render on every hue drag.
   classification still correct) — the env line under the demo reports support.
 - A canvas that has handed out a WebGL context can't also give a `2d` context, so
   the GPU-vs-CPU choice must be made per canvas before first paint.
-- Arm C's "issue" time excludes GPU completion (the library doesn't expose its
-  context for a `finish()`); Arm B's number includes a `gl.finish()`, so B's ms
-  looks larger than C's despite doing the same class of work. Compare the
-  **throughput** counters for an end-to-end read.
+- Both GPU arms are now timed with a `gl.finish()` (Arm C via the exposed
+  `renderer.gl`), so their benchmark numbers are directly comparable; the
+  **throughput** counters remain the best end-to-end read.
+- `@colordx/gpu@0.5.0` ships `math.maxChromaLUT()` but it's missing from the
+  published `math.d.ts`, so this prototype calls it through a small cast.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@astrojs/netlify": "^6.6.0",
         "@astrojs/starlight": "^0.36.2",
-        "@colordx/gpu": "^0.5.2",
+        "@colordx/gpu": "^0.6.0",
         "@types/jsdom": "^21.1.7",
         "autoprefixer": "^10.4.19",
         "jsdom": "^24.1.0",
@@ -857,9 +857,9 @@
       }
     },
     "node_modules/@colordx/gpu": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.2.tgz",
-      "integrity": "sha512-cvKy4boJ3X34oKIieJM1wZFonYfiY8vbOUx+3561Ef8iLjTkOK4n/g+1122FvVOtWTpdgA81FL6ukAHktQxGZg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.6.0.tgz",
+      "integrity": "sha512-hB6tIgU34TmwXr9VCRBfld3TTsCFobhyNer3rZdwWPGOwiJvzfe0H6yuAELExnJEOA0+w9nBAxJ+KhMoCMUV5g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@astrojs/netlify": "^6.6.0",
         "@astrojs/starlight": "^0.36.2",
-        "@colordx/gpu": "^0.5.0",
+        "@colordx/gpu": "^0.5.2",
         "@types/jsdom": "^21.1.7",
         "autoprefixer": "^10.4.19",
         "jsdom": "^24.1.0",
@@ -857,9 +857,9 @@
       }
     },
     "node_modules/@colordx/gpu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.0.tgz",
-      "integrity": "sha512-5uDoUezXcQ5zZq1wyoiaNOs7gYmzbW8klXlPaD6rHsQ80c4JIUoQE/SumuxuglqbKbKhEOGCw4OcEnu1lR9Tig==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.2.tgz",
+      "integrity": "sha512-cvKy4boJ3X34oKIieJM1wZFonYfiY8vbOUx+3561Ef8iLjTkOK4n/g+1122FvVOtWTpdgA81FL6ukAHktQxGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@astrojs/netlify": "^6.6.0",
         "@astrojs/starlight": "^0.36.2",
+        "@colordx/gpu": "^0.2.1",
         "@types/jsdom": "^21.1.7",
         "autoprefixer": "^10.4.19",
         "jsdom": "^24.1.0",
@@ -47,7 +48,8 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
       "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.4",
@@ -723,6 +725,7 @@
       "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.2.0",
         "debug": "^4.4.0",
@@ -845,12 +848,20 @@
       "integrity": "sha512-+ntATQe1AlL7nTOYjwjj6w3299CgRot48wL761TUGYpYgAou3AaONZazp0PKZyCyWhudWsjhq1nvRHOvbMzhTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontkit": "^2.0.2"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@colordx/gpu": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.2.1.tgz",
+      "integrity": "sha512-rq5kURztFXqZ9jveztVsKmQWRnpnPvJ5cCbLuQdOoJtbeyGMXK20guVIhouTnfIHclu4QslXPekviMgdALq4rQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -950,7 +961,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -974,7 +984,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4134,7 +4143,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4385,7 +4393,8 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pagefind/darwin-arm64": {
       "version": "1.4.0",
@@ -5564,6 +5573,7 @@
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -5608,6 +5618,7 @@
       "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6219,7 +6230,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6276,7 +6286,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6344,6 +6353,7 @@
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
@@ -6354,6 +6364,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6363,7 +6374,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-align/node_modules/string-width": {
       "version": "4.2.3",
@@ -6371,6 +6383,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6386,6 +6399,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6527,6 +6541,7 @@
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6685,6 +6700,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6702,6 +6718,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6719,6 +6736,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6736,6 +6754,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6753,6 +6772,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6770,6 +6790,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6787,6 +6808,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6804,6 +6826,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6821,6 +6844,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6838,6 +6862,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6855,6 +6880,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6872,6 +6898,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6889,6 +6916,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6906,6 +6934,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6923,6 +6952,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6940,6 +6970,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6957,6 +6988,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6974,6 +7006,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6991,6 +7024,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7008,6 +7042,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7025,6 +7060,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7042,6 +7078,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7059,6 +7096,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7070,6 +7108,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7111,6 +7150,7 @@
       "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^1.1.1"
       },
@@ -7127,6 +7167,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7261,6 +7302,7 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7318,7 +7360,8 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -7467,6 +7510,7 @@
       "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-align": "^3.0.1",
         "camelcase": "^8.0.0",
@@ -7513,6 +7557,7 @@
       "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.1.2"
       }
@@ -7537,7 +7582,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -7640,6 +7684,7 @@
       "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -7806,6 +7851,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7833,6 +7879,7 @@
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7971,6 +8018,7 @@
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -7981,6 +8029,7 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8112,7 +8161,8 @@
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
       "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -8728,6 +8778,7 @@
       "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base-64": "^1.0.0"
       },
@@ -8747,7 +8798,8 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.4.2.tgz",
       "integrity": "sha512-MwPZTKEPK2k8Qgfmqrd48ZKVvzSQjgW0lXLxiIBA8dQjtf/6mw6pggHNLcyDKyf+fI6eXxlQwPsfaCMTU5U+Bw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -8768,7 +8820,8 @@
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -8776,6 +8829,7 @@
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8809,7 +8863,8 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -8918,6 +8973,7 @@
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8966,7 +9022,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/empathic": {
       "version": "2.0.0",
@@ -9375,7 +9432,8 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9695,6 +9753,7 @@
       "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9712,6 +9771,7 @@
       "integrity": "sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/fontkit": "^2.0.8",
         "fontkit": "^2.0.4"
@@ -9723,6 +9783,7 @@
       "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.12",
         "brotli": "^1.3.2",
@@ -9876,6 +9937,7 @@
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10563,7 +10625,8 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
@@ -10592,7 +10655,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -11206,7 +11270,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -11357,6 +11420,7 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11658,6 +11722,7 @@
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
@@ -13033,6 +13098,7 @@
       "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13076,6 +13142,7 @@
       "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -13335,7 +13402,8 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/omit.js": {
       "version": "2.0.2",
@@ -13489,6 +13557,7 @@
       "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"
@@ -13559,7 +13628,8 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.5.0.tgz",
       "integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pagefind": {
       "version": "1.4.0",
@@ -13584,7 +13654,8 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -13841,7 +13912,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14020,6 +14090,7 @@
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -14688,7 +14759,8 @@
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/retext": {
       "version": "9.0.0",
@@ -15028,7 +15100,8 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sitemap": {
       "version": "8.0.2",
@@ -15231,6 +15304,7 @@
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -15520,7 +15594,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15574,7 +15647,8 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -15588,7 +15662,8 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -15754,6 +15829,7 @@
       "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "tsconfck": "bin/tsconfck.js"
       },
@@ -15805,7 +15881,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15858,6 +15933,7 @@
       "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
@@ -15869,6 +15945,7 @@
       "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
@@ -15913,6 +15990,7 @@
       "integrity": "sha512-5Fx50fFQMQL5aeHyWnZX9122sSLckcDvcfFiBf3QYeHa7a1MKJooUy52b67moi2MJYkrfo/TWY+CoLdr/w0tTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0",
         "ofetch": "^1.4.1",
@@ -16372,7 +16450,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -16527,6 +16604,7 @@
       "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "tests/deps/*",
         "tests/projects/*",
@@ -16717,6 +16795,7 @@
       "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -16744,6 +16823,7 @@
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^7.0.0"
       },
@@ -16841,6 +16921,7 @@
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -16952,6 +17033,7 @@
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17048,7 +17130,8 @@
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -17197,6 +17280,7 @@
       "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yoctocolors": "^2.1.1"
       },
@@ -17213,6 +17297,7 @@
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -17241,7 +17326,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17252,6 +17336,7 @@
       "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }
@@ -17261,6 +17346,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
       "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "typescript": "^4.9.4 || ^5.0.2",
         "zod": "^3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@astrojs/netlify": "^6.6.0",
         "@astrojs/starlight": "^0.36.2",
-        "@colordx/gpu": "^0.2.1",
+        "@colordx/gpu": "^0.5.0",
         "@types/jsdom": "^21.1.7",
         "autoprefixer": "^10.4.19",
         "jsdom": "^24.1.0",
@@ -857,9 +857,9 @@
       }
     },
     "node_modules/@colordx/gpu": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.2.1.tgz",
-      "integrity": "sha512-rq5kURztFXqZ9jveztVsKmQWRnpnPvJ5cCbLuQdOoJtbeyGMXK20guVIhouTnfIHclu4QslXPekviMgdALq4rQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.0.tgz",
+      "integrity": "sha512-5uDoUezXcQ5zZq1wyoiaNOs7gYmzbW8klXlPaD6rHsQ80c4JIUoQE/SumuxuglqbKbKhEOGCw4OcEnu1lR9Tig==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@astrojs/netlify": "^6.6.0",
     "@astrojs/starlight": "^0.36.2",
-    "@colordx/gpu": "^0.5.0",
+    "@colordx/gpu": "^0.5.2",
     "@types/jsdom": "^21.1.7",
     "autoprefixer": "^10.4.19",
     "jsdom": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@astrojs/netlify": "^6.6.0",
     "@astrojs/starlight": "^0.36.2",
+    "@colordx/gpu": "^0.2.1",
     "@types/jsdom": "^21.1.7",
     "autoprefixer": "^10.4.19",
     "jsdom": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@astrojs/netlify": "^6.6.0",
     "@astrojs/starlight": "^0.36.2",
-    "@colordx/gpu": "^0.2.1",
+    "@colordx/gpu": "^0.5.0",
     "@types/jsdom": "^21.1.7",
     "autoprefixer": "^10.4.19",
     "jsdom": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@astrojs/netlify": "^6.6.0",
     "@astrojs/starlight": "^0.36.2",
-    "@colordx/gpu": "^0.5.2",
+    "@colordx/gpu": "^0.6.0",
     "@types/jsdom": "^21.1.7",
     "autoprefixer": "^10.4.19",
     "jsdom": "^24.1.0",


### PR DESCRIPTION
## What & why

An exploration prompted by [“Blazing-fast color manipulation at scale on the GPU”](https://dkryaklin.com/blog/colordx-gpu) (Dima Kryaklin). The post argues that per-pixel color work belongs in a fragment shader, not on the CPU. Our **area picker is a textbook instance of the “before” it describes**: `src/area-picker.worker.ts` converts every pixel with colorjs.io in a Web Worker, at **quarter backing resolution**, then upscales with `drawImage()`, and draws gamut boundaries as **sampled polylines**.

This PR doesn’t change the shipping component. It adds a docs page that renders the **OKLCH hue slice three independent ways** so we can compare them and decide whether to adopt the technique.

> ⚠️ Prototype on a branch. Test it on the **Netlify Deploy Preview** for this PR → **Docs → “GPU Comparison (prototype)”**. Drag the hue, hit **auto-sweep**, run **benchmark**.

## The three arms

| | A — current | B — custom WebGL2 shader | C — `@colordx/gpu` |
|---|---|---|---|
| Per-pixel math | CPU (colorjs.io), worker | GPU fragment shader | GPU fragment shader |
| Resolution | ¼ backing, upscaled (blurry) | full backing, crisp | full backing, crisp |
| Gamut boundary | sampled polyline (~100 pts + bisection) | analytic contour in-shader | analytic contour in-shader |
| Per-frame allocation | 250k–1M short-lived objects | none | none |
| Color spaces | all (okhsv/oklch/hsl/oklab/lab/hwb) | only what you write GLSL for | OKLCH + CIE LCH only |
| Slice orientation | chroma→x, lightness→y | chroma→x, lightness→y | lightness→x, chroma→y (`'cl'`) |
| Chroma stretch-to-gamut | yes (per-row LUT) | yes (per-row LUT) | no (absolute coords) |
| New dependency | none (ships today) | none (hand-written GLSL) | `@colordx/gpu` |
| Maintenance | owned, slow by design | **you own a parallel GLSL impl** | upstream owns it; less control |

## Measured CPU baseline (Arm A)

colorjs.io OKLCH→Display-P3, Node v24, M-series laptop, median of 9:

| measurement | value |
|---|---|
| per-conversion | **~617 ns** (~1.6M/s) — note colorjs is ~3× colordx’s cited 213 ns |
| frame @ ¼-res (140×88 ≈ 12k px) | **~7.6 ms** — what ships today |
| frame @ full-res (560×350 ≈ 196k px) | **~117 ms** (~7 fps) — why CPU full-res is a non-starter |

A fragment shader produces that full-res frame in well under a millisecond, off the main thread — the ~100×+ gap the article describes, reproduced on our exact slice. GPU numbers are hardware/browser dependent; read them off the live demo. (The in-page benchmark times Arm B with a `gl.finish()` and Arm C as paint-issue only, since the library doesn’t expose its context — compare the **throughput** counters for an end-to-end read.)

## Findings

- **Both GPU arms remove the worker round-trip, the ¼-res blur, and the per-pixel allocation.** Crisp at full DPR; fullscreen repaint is effectively free.
- **A custom shader (B) reproduces our slice exactly** — same orientation and per-row chroma stretch (a 128-entry LUT, ~2k conversions per hue change vs ~250k per frame today).
- **The library (C) is the least code but least flexible:** its own plane conventions, absolute coordinates (no stretch), OKLCH/CIE LCH only, sRGB/P3/Rec2020 boundaries only. It can’t cover our other spaces (okhsv, hsl, oklab, lab, hwb) or gamuts (a98rgb, prophoto), so it’d be an OKLCH/LCH-only fast path beside the existing CPU one — not a drop-in.

## Recommendation / tradeoffs

1. **Adopt the technique for the OKLCH/OKLab/LCH slices** — full-res, no GC hitches, exact boundaries.
2. **Prefer the custom shader (B) over the library (C)** for integration: it matches our orientation + stretch UX and adds no dependency — at the cost of owning a GLSL impl that must be **parity-tested against colorjs.io** (the article’s “one constants module → both impls + parity test” discipline).
3. **Keep colorjs.io as the CPU path** for spaces a shader doesn’t cover and as the WebGL2-unavailable fallback; it wins per-call work (parsing, the selected-color readout) where the GPU’s fixed latency loses.
4. **`@colordx/gpu` is the fastest way to validate the idea** (this PR uses it live) and a fine choice if we ever expose an OKLCH-only “chart” mode.

### Caveats observed
- Firefox lacks WebGL `display-p3`; GPU arms clip to sRGB there (classification stays correct). The demo’s env line reports support.
- A canvas that handed out a WebGL context can’t also give `2d` — decide GPU vs CPU per canvas before first paint.

## Changes
- `docs/src/content/docs/gpu-comparison.mdx` — the page + written report
- `docs/src/components/OklchGpuComparison.astro` — 3-way harness (Arm B shader + Arm C wiring + Arm A orchestration, controls, instrumentation)
- `docs/src/components/cpu-oklch.worker.ts` — Arm A worker (faithful OKLCH-only copy of the current path)
- `docs/{package,astro.config}` — add `@colordx/gpu`, register the page

Custom GLSL borrows standard color matrices from `@colordx/gpu` (MIT). Local `npm run build` passes; `dist/` stays untracked.

## Not done (follow-ups if we proceed)
- Wire Arm B into the real `<color-input>` behind a flag, with a WebGL2→CPU fallback.
- A parity test pinning the GLSL constants to colorjs.io output.
- Extend the shader to OKLab/LCH (and decide on hsl/hwb/lab CPU-only).
