### PR TITLE
Spike: GPU-accelerate the OKLCH area slice via @colordx/gpu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
+        "@colordx/gpu": "^0.5.2",
         "@preact/signals-core": "^1.6.0",
         "colorjs.io": "^0.6.1"
       },
@@ -47,7 +48,8 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
       "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.4",
@@ -723,6 +725,7 @@
       "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.2.0",
         "debug": "^4.4.0",
@@ -845,12 +848,19 @@
       "integrity": "sha512-+ntATQe1AlL7nTOYjwjj6w3299CgRot48wL761TUGYpYgAou3AaONZazp0PKZyCyWhudWsjhq1nvRHOvbMzhTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontkit": "^2.0.2"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@colordx/gpu": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@colordx/gpu/-/gpu-0.5.2.tgz",
+      "integrity": "sha512-cvKy4boJ3X34oKIieJM1wZFonYfiY8vbOUx+3561Ef8iLjTkOK4n/g+1122FvVOtWTpdgA81FL6ukAHktQxGZg==",
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -950,7 +960,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -974,7 +983,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4134,7 +4142,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4385,7 +4392,8 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pagefind/darwin-arm64": {
       "version": "1.4.0",
@@ -5564,6 +5572,7 @@
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -5608,6 +5617,7 @@
       "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6219,7 +6229,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6276,7 +6285,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6344,6 +6352,7 @@
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
@@ -6354,6 +6363,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6363,7 +6373,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-align/node_modules/string-width": {
       "version": "4.2.3",
@@ -6371,6 +6382,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6386,6 +6398,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6527,6 +6540,7 @@
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6685,6 +6699,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6702,6 +6717,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6719,6 +6735,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6736,6 +6753,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6753,6 +6771,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6770,6 +6789,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6787,6 +6807,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6804,6 +6825,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6821,6 +6843,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6838,6 +6861,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6855,6 +6879,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6872,6 +6897,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6889,6 +6915,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6906,6 +6933,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6923,6 +6951,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6940,6 +6969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6957,6 +6987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6974,6 +7005,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6991,6 +7023,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7008,6 +7041,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7025,6 +7059,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7042,6 +7077,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7059,6 +7095,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7070,6 +7107,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7111,6 +7149,7 @@
       "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^1.1.1"
       },
@@ -7127,6 +7166,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7261,6 +7301,7 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7318,7 +7359,8 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -7467,6 +7509,7 @@
       "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-align": "^3.0.1",
         "camelcase": "^8.0.0",
@@ -7513,6 +7556,7 @@
       "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.1.2"
       }
@@ -7537,7 +7581,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -7640,6 +7683,7 @@
       "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -7806,6 +7850,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7833,6 +7878,7 @@
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7971,6 +8017,7 @@
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -7981,6 +8028,7 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8112,7 +8160,8 @@
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
       "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -8728,6 +8777,7 @@
       "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base-64": "^1.0.0"
       },
@@ -8747,7 +8797,8 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.4.2.tgz",
       "integrity": "sha512-MwPZTKEPK2k8Qgfmqrd48ZKVvzSQjgW0lXLxiIBA8dQjtf/6mw6pggHNLcyDKyf+fI6eXxlQwPsfaCMTU5U+Bw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -8768,7 +8819,8 @@
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -8776,6 +8828,7 @@
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8809,7 +8862,8 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -8918,6 +8972,7 @@
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8966,7 +9021,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/empathic": {
       "version": "2.0.0",
@@ -9375,7 +9431,8 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9695,6 +9752,7 @@
       "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9712,6 +9770,7 @@
       "integrity": "sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/fontkit": "^2.0.8",
         "fontkit": "^2.0.4"
@@ -9723,6 +9782,7 @@
       "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.12",
         "brotli": "^1.3.2",
@@ -9876,6 +9936,7 @@
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10563,7 +10624,8 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
@@ -10592,7 +10654,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -11206,7 +11269,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -11357,6 +11419,7 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11658,6 +11721,7 @@
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
@@ -13033,6 +13097,7 @@
       "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13076,6 +13141,7 @@
       "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -13335,7 +13401,8 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/omit.js": {
       "version": "2.0.2",
@@ -13489,6 +13556,7 @@
       "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"
@@ -13559,7 +13627,8 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.5.0.tgz",
       "integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pagefind": {
       "version": "1.4.0",
@@ -13584,7 +13653,8 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -13841,7 +13911,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14020,6 +14089,7 @@
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -14688,7 +14758,8 @@
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/retext": {
       "version": "9.0.0",
@@ -15028,7 +15099,8 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sitemap": {
       "version": "8.0.2",
@@ -15231,6 +15303,7 @@
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -15520,7 +15593,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15574,7 +15646,8 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -15588,7 +15661,8 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -15754,6 +15828,7 @@
       "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "tsconfck": "bin/tsconfck.js"
       },
@@ -15805,7 +15880,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15858,6 +15932,7 @@
       "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
@@ -15869,6 +15944,7 @@
       "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
@@ -15913,6 +15989,7 @@
       "integrity": "sha512-5Fx50fFQMQL5aeHyWnZX9122sSLckcDvcfFiBf3QYeHa7a1MKJooUy52b67moi2MJYkrfo/TWY+CoLdr/w0tTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0",
         "ofetch": "^1.4.1",
@@ -16372,7 +16449,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -16527,6 +16603,7 @@
       "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "tests/deps/*",
         "tests/projects/*",
@@ -16717,6 +16794,7 @@
       "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -16744,6 +16822,7 @@
       "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^7.0.0"
       },
@@ -16841,6 +16920,7 @@
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -16952,6 +17032,7 @@
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17048,7 +17129,8 @@
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -17197,6 +17279,7 @@
       "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yoctocolors": "^2.1.1"
       },
@@ -17213,6 +17296,7 @@
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -17241,7 +17325,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17252,6 +17335,7 @@
       "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }
@@ -17261,6 +17345,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
       "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "typescript": "^4.9.4 || ^5.0.2",
         "zod": "^3"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "release": "npm run build:prod && npm publish"
   },
   "dependencies": {
+    "@colordx/gpu": "^0.5.2",
     "@preact/signals-core": "^1.6.0",
     "colorjs.io": "^0.6.1"
   },

--- a/src/area-picker-gpu.ts
+++ b/src/area-picker-gpu.ts
@@ -1,0 +1,130 @@
+// GPU render path for the area picker, backed by @colordx/gpu.
+//
+// Scope: the OKLCH lightness×chroma slice (the 'cl' plane, fixed hue) — which is
+// also what every wide-gamut RGB space falls back to (see AreaPicker.setValue).
+// Everything else (oklab/lab, and the sRGB-cylindrical hsl/hwb/okhsv) stays on
+// the existing colorjs CPU path.
+//
+// A canvas can only ever hand out one context type, so we can't flip the CPU
+// 2d canvas to WebGL and back as the user switches spaces. Instead we add a
+// second, stacked WebGL canvas and toggle which one is visible — no DOM surgery
+// per switch, and the .area-thumb (z-index:1) stays on top of both.
+
+import { createChartRenderer, math } from '@colordx/gpu'
+
+type ChartRenderer = NonNullable<ReturnType<typeof createChartRenderer>>
+
+// internal spaceId (post-setValue) → GPU eligible?
+export function gpuSupportsSpace(spaceId: string): boolean {
+  return spaceId === 'oklch'
+}
+
+export function gpuAreaSupported(): boolean {
+  try {
+    return !!document.createElement('canvas').getContext('webgl2')
+  } catch {
+    return false
+  }
+}
+
+// component gamut id → @colordx/gpu GamutSpace
+const GAMUT_ID: Record<string, 'srgb' | 'p3' | 'a98' | 'rec2020' | 'prophoto'> = {
+  srgb: 'srgb',
+  p3: 'p3',
+  a98rgb: 'a98',
+  rec2020: 'rec2020',
+  'prophoto-rgb': 'prophoto',
+}
+
+// inner gamut boundary lines drawn inside each stretch gamut (matches the CPU
+// path's visible lines; a98↔p3 are siblings so we draw only the clearly-nested
+// ones). The library draws solid AA lines — the CPU path dashes the outer ones.
+const INNER_BORDERS: Record<string, { space: 'srgb' | 'p3' | 'a98' | 'rec2020'; color: [number, number, number, number] }[]> = {
+  srgb: [],
+  p3: [{ space: 'srgb', color: [1, 1, 1, 0.7] }],
+  a98: [{ space: 'srgb', color: [1, 1, 1, 0.7] }],
+  rec2020: [
+    { space: 'srgb', color: [1, 1, 1, 0.7] },
+    { space: 'p3', color: [1, 1, 1, 0.55] },
+  ],
+  prophoto: [
+    { space: 'srgb', color: [1, 1, 1, 0.7] },
+    { space: 'p3', color: [1, 1, 1, 0.55] },
+    { space: 'rec2020', color: [1, 1, 1, 0.4] },
+  ],
+}
+
+export class GpuAreaRenderer {
+  #canvas: HTMLCanvasElement
+  #renderer: ChartRenderer | null = null
+
+  constructor(container: HTMLElement) {
+    this.#canvas = document.createElement('canvas')
+    this.#canvas.className = 'area-canvas-gl'
+    this.#canvas.hidden = true
+    // insert before the thumb so the thumb keeps painting on top
+    const thumb = container.querySelector('.area-thumb')
+    container.insertBefore(this.#canvas, thumb)
+    this.#renderer = createChartRenderer(this.#canvas, { model: 'oklch' })
+  }
+
+  get ok(): boolean {
+    return !!this.#renderer
+  }
+
+  show() {
+    this.#canvas.hidden = false
+  }
+
+  hide() {
+    this.#canvas.hidden = true
+  }
+
+  // Per-row max-chroma LUT, from the same colordx math the shader runs, so the
+  // stretch the GPU paints and the thumb mapping use identical values.
+  buildStretchLUT(hue: number, stretchGamut: string): Float32Array {
+    const gamut = GAMUT_ID[stretchGamut] ?? 'p3'
+    return math.maxChromaLUT({ model: 'oklch', hue, gamut })
+  }
+
+  paint(opts: {
+    hue: number
+    chromaLUT: Float32Array
+    stretchGamut: string
+    supportsP3: boolean
+    dpr: number
+    cssW: number
+    cssH: number
+  }): boolean {
+    const r = this.#renderer
+    if (!r) return false
+    const gamut = GAMUT_ID[opts.stretchGamut] ?? 'p3'
+    const backingW = Math.round(opts.cssW * opts.dpr)
+    const backingH = Math.round(opts.cssH * opts.dpr)
+    if (this.#canvas.width !== backingW) this.#canvas.width = backingW
+    if (this.#canvas.height !== backingH) this.#canvas.height = backingH
+
+    const gamuts = [
+      { space: gamut, fill: true },
+      ...(INNER_BORDERS[gamut] ?? []).map((b) => ({ space: b.space, border: b.color })),
+    ]
+
+    return r.paint({
+      plane: 'cl', // x: lightness, y: chroma, fixed hue …
+      transpose: true, // … transposed to chroma→x / lightness→y to match the picker
+      value: opts.hue,
+      xMax: 1, // OKLCH lightness 0–1
+      yMax: 0.4, // chroma axis; chromaLUT overrides with the per-row stretch
+      chromaLUT: opts.chromaLUT,
+      gamuts: gamuts as any,
+      borderWidth: 1.5 * opts.dpr,
+      p3Output: opts.supportsP3,
+    })
+  }
+
+  destroy() {
+    this.#renderer?.destroy()
+    this.#renderer = null
+    this.#canvas.remove()
+  }
+}

--- a/src/area-picker.ts
+++ b/src/area-picker.ts
@@ -3,6 +3,7 @@ import { ColorConstructor, inGamut, serialize, to } from "colorjs.io/fn";
 import { getColorJSSpaceID, isRGBLike, type ColorSpace } from "./color";
 import { gencolor, parseIntoChannels } from "./utils/color-conversion";
 import AreaPickerWorker from './area-picker.worker.ts?worker&inline';
+import { GpuAreaRenderer, gpuAreaSupported, gpuSupportsSpace } from "./area-picker-gpu";
 
 type AreaConfig = {
   fixedIndex: number;
@@ -616,6 +617,8 @@ export class AreaPicker {
   #lastRenderedId = 0;
   #workerBusy = false;
   #pendingWorkerMsg: any = null;
+  #gpu: GpuAreaRenderer | null = null;
+  #gpuTried = false;
 
   constructor(
     element: null | HTMLElement,
@@ -948,7 +951,41 @@ export class AreaPicker {
                 ? getColorJSSpaceID(this.#space.value === 'hex' ? 'srgb' : this.#space.value)
                 : '';
 
-              if (this.#worker) {
+              // Lazily spin up the GPU renderer the first time an OKLCH slice is
+              // actually requested — keeps the WebGL context budget for pickers
+              // that never show a GPU-eligible space.
+              const gpuEligible = gpuSupportsSpace(color.spaceId) && config.gamutBoundary === 'row-scan';
+              if (gpuEligible && !this.#gpu && !this.#gpuTried && gpuAreaSupported()) {
+                this.#gpuTried = true;
+                try {
+                  const gpu = new GpuAreaRenderer(element);
+                  if (gpu.ok) this.#gpu = gpu;
+                  else gpu.destroy();
+                } catch { this.#gpu = null; }
+              }
+              const useGpu = gpuEligible && !!this.#gpu;
+              if (useGpu) {
+                // GPU fast path (OKLCH slice): paint the stacked WebGL canvas and
+                // hide the 2d one. Reuse the same LUT for the thumb mapping.
+                const stretchGamut = getStretchGamut(userSpaceId);
+                const lut = this.#gpu!.buildStretchLUT(pendingHue ?? 0, stretchGamut);
+                this.#effectiveConfig.value = config;
+                this.#chromaLUT.value = Float64Array.from(lut);
+                this.#polarLUT.value = null;
+                canvas.hidden = true;
+                this.#gpu!.show();
+                this.#gpu!.paint({
+                  hue: pendingHue ?? 0,
+                  chromaLUT: lut,
+                  stretchGamut,
+                  supportsP3: supportsP3Canvas,
+                  dpr,
+                  cssW: element.clientWidth || 320,
+                  cssH: element.clientHeight || 200,
+                });
+              } else if (this.#worker) {
+                this.#gpu?.hide();
+                canvas.hidden = false;
                 // Worker path: only one message in-flight at a time
                 const msg = {
                   id: ++this.#renderSeqId,
@@ -967,6 +1004,8 @@ export class AreaPicker {
                   this.#worker.postMessage(msg);
                 }
               } else {
+                this.#gpu?.hide();
+                canvas.hidden = false;
                 // Synchronous fallback when worker is unavailable
                 let effCfg = config;
                 let chromaLUT: Float64Array | null = null;
@@ -1069,5 +1108,7 @@ export class AreaPicker {
     this.#controller.abort();
     this.#worker?.terminate();
     this.#worker = null;
+    this.#gpu?.destroy();
+    this.#gpu = null;
   }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -188,7 +188,8 @@ button {
   outline-offset: 0px;
 }
 
-.area-canvas {
+.area-canvas,
+.area-canvas-gl {
   position: absolute;
   inset: 0;
   width: 100%;


### PR DESCRIPTION
## What this is

A **spike** to attempt the real integration and see the full picture — not (yet) a merge candidate. It wires [`@colordx/gpu`](https://github.com/dkryaklin/colordx-gpu) into the actual `<color-input>` area picker as a GPU fast path for the **OKLCH lightness×chroma slice**, replacing the per-pixel colorjs worker + quarter-res upscale for that case.

Companion to the docs comparison in #68 (which evaluates the approach in isolation). This one makes the shipping component actually faster.

## Why OKLCH only (for now)

`AreaPicker.setValue` already funnels **oklch, lch, and every wide-gamut RGB space** into an OKLCH slice — so accelerating just OKLCH covers the dominant wide-gamut path. `oklab`/`lab` (Cartesian a/b planes) and the sRGB-cylindrical `hsl`/`hwb`/`okhsv` stay on the existing CPU path. See the checklist for what blocks the rest.

## How it works

- **`src/area-picker-gpu.ts`** wraps the library's chart renderer in the picker's conventions: `transpose` (chroma→x / lightness→y), per-row chroma stretch via `math.maxChromaLUT`, layered gamut fills/borders, and p3 output.
- **Canvas context lock** — a canvas can only ever hand out one context type, so we can't flip the 2d canvas to WebGL and back as the user switches spaces. Solved with a **second, stacked `.area-canvas-gl`**; visibility toggles per space and the `.area-thumb` (z-index:1) stays on top of both. No per-switch DOM surgery.
- **Lazy context creation** — the WebGL context is created on the *first* OKLCH render, not at construction, so pickers that never show a GPU-eligible space don't spend a context (see context-budget caveat).
- **Interaction unchanged** — thumb / pointer / keyboard math still read the `#chromaLUT` signal; the GPU path sets that signal to the *same* `maxChromaLUT` it paints with, so the marker stays pixel-aligned with the render.
- **Fallback** — no WebGL2 (or `createChartRenderer` returns null) → the existing worker/CPU path, untouched.

## Measured impact

- **Bundle:** 183.3 KB → 198.2 KB raw (**+14.9 KB**, +8%); 68.0 KB → 73.8 KB gzip (**+5.7 KB**). `@colordx/gpu` is bundled (the lib build externalizes nothing).
- **Tests:** all **219 pass** (jsdom has no WebGL2, so it exercises the unchanged CPU fallback).
- **Render:** OKLCH slice is now full-res + crisp with no worker round-trip or per-pixel GC (the ~100× per-pixel gap quantified in #68); fixed-channel drag no longer re-runs a 250k-pixel CPU pass.

## Tradeoffs to weigh

- **+5.7 KB gzip** for a GPU path that only covers OKLCH-family spaces today — worth it depends on how much the area picker's drag smoothness/crispness matters vs. bundle.
- **One WebGL context per picker** that shows an OKLCH slice. Browsers cap ~16 live contexts; a page with many pickers (the docs site!) could hit it. Lazy creation helps; a shared/pooled renderer would be the real fix.
- **Boundary fidelity:** the library draws solid AA lines; the CPU path dashes the *outer* gamut boundaries. Default P3 stretch (one solid sRGB line) matches; focused multi-gamut modes lose the dash distinction. a98↔p3 are siblings, so only clearly-nested borders are drawn.
- **Two render paths to keep visually consistent** (stretch, borders, DPR, P3) — a maintenance cost.

## Checklist to productionize

**Library-side (one open ask):**
- [ ] **Radial/polar stretch for `oklab`/`lab` Cartesian planes** — `chromaLUT`/`maxChromaLUT` are polar `'cl'` only, so GPU oklab/lab would render absolute a/b coords (gamut doesn't fill the square). This is the last thing blocking full wide-gamut coverage. (Tracked in [colordx-gpu#8](https://github.com/dkryaklin/colordx-gpu/issues/8).)
- [ ] Optional: dashed-border support (or accept solid AA lines for outer gamuts).

**Our side:**
- [ ] Decide bundle vs. value; consider a pooled/shared WebGL renderer to bound the context budget across many pickers.
- [ ] Extend coverage to `oklab`/`lab` once the library ships radial stretch.
- [ ] Visual QA in the real component across spaces / themes / alpha / focused-gamut modes (Netlify preview).
- [ ] A GPU/CPU-parity guard or screenshot test (current vitest is jsdom-only; GPU can't run there).
- [ ] Confirm behavior with many `<color-input>`s on one page (context exhaustion).

## How to verify
The Netlify Deploy Preview renders the real `<color-input>` with this integration — drag the area on an OKLCH/Display-P3/Rec2020 value and watch it stay crisp and smooth; switch to HSL/HWB to confirm the CPU path still kicks in (canvas swap). Or `git checkout gpu-area-picker-integration && npm i && npm run dev`.
