### PR TITLE
Perf: eliminate controls DOM rebuild during area drags + per-frame canvas allocations

### DIFF
--- a/src/area-picker.ts
+++ b/src/area-picker.ts
@@ -630,6 +630,9 @@ export class AreaPicker {
     // Initialize worker for off-thread gradient computation
     try {
       this.#worker = new AreaPickerWorker();
+      // Scratch canvas reused across frames to avoid per-frame allocation
+      let offscreen: HTMLCanvasElement | null = null;
+      let offCtx: CanvasRenderingContext2D | null = null;
       this.#worker.onmessage = (e: MessageEvent) => {
         const result = e.data;
         if (result.id < this.#lastRenderedId) return; // discard stale
@@ -642,17 +645,30 @@ export class AreaPicker {
 
         // Paint pixel data to canvas
         const canvasColorSpace = supportsP3Canvas ? "display-p3" : "srgb";
-        const offscreen = document.createElement("canvas");
-        offscreen.width = result.W;
-        offscreen.height = result.H;
-        const offCtx = offscreen.getContext("2d", { colorSpace: canvasColorSpace });
+        if (!offscreen) {
+          offscreen = document.createElement("canvas");
+          offscreen.width = result.W;
+          offscreen.height = result.H;
+          offCtx = offscreen.getContext("2d", { colorSpace: canvasColorSpace });
+        } else if (offscreen.width !== result.W || offscreen.height !== result.H) {
+          offscreen.width = result.W;
+          offscreen.height = result.H;
+        }
         if (!offCtx) return;
-        const img = offCtx.createImageData(result.W, result.H);
-        img.data.set(new Uint8ClampedArray(result.pixels));
+        // View over the transferred buffer — no copy; tag it so putImageData
+        // writes raw values instead of color-converting
+        const img = new ImageData(
+          new Uint8ClampedArray(result.pixels),
+          result.W,
+          result.H,
+          supportsP3Canvas ? { colorSpace: "display-p3" } : undefined
+        );
         offCtx.putImageData(img, 0, 0);
 
-        canvas.width = result.backingW;
-        canvas.height = result.backingH;
+        // Setting width/height reallocates the backing store; skip when unchanged
+        // (drawImage below covers the full canvas, so no explicit clear is needed)
+        if (canvas.width !== result.backingW) canvas.width = result.backingW;
+        if (canvas.height !== result.backingH) canvas.height = result.backingH;
         const ctx = canvas.getContext("2d", { colorSpace: canvasColorSpace });
         if (!ctx) return;
         ctx.imageSmoothingEnabled = true;

--- a/src/color-input.ts
+++ b/src/color-input.ts
@@ -1,4 +1,4 @@
-import { signal, computed, effect, Signal } from '@preact/signals-core'
+import { signal, computed, effect, batch, Signal } from '@preact/signals-core'
 import { parse, serialize, to, toGamut, contrast as contrastFn } from 'colorjs.io/fn'
 import {
   contrastColor,
@@ -12,7 +12,7 @@ import {
 } from './color'
 import { AreaPicker } from './area-picker'
 import { formatChannel } from './utils/channel-formatting'
-import { gencolor, parseIntoChannels } from './utils/color-conversion'
+import { gencolor, parseIntoChannels, type ChannelRecord } from './utils/color-conversion'
 import {
   computeCandidates,
   findFirstFitOrMaxArea,
@@ -66,6 +66,7 @@ export class ColorInput extends HTMLElement {
   #colorSchemeEffectCleanup: ReturnType<typeof effect> | null = null
   #errorEffectCleanup: ReturnType<typeof effect> | null = null
   #controlsEffectCleanup: ReturnType<typeof effect> | null = null
+  #controlsUpdate: ((ch: ChannelRecord) => void) | null = null
   #areaPickerEffectCleanup: ReturnType<typeof effect> | null = null
   #areaPicker?: AreaPicker
   #programmaticUpdate = false
@@ -208,7 +209,7 @@ export class ColorInput extends HTMLElement {
         this.setAttribute('value', color)
         this.#programmaticUpdate = false
         this.#emitChange()
-        this.#renderControls()
+        this.#updateControls()
       })
 
       // Sync area picker when color changes
@@ -344,8 +345,8 @@ export class ColorInput extends HTMLElement {
     })
 
     this.#spaceSelect.addEventListener('change', () => {
+      // the colorspace setter re-renders controls itself
       this.colorspace = this.#spaceSelect!.value as ColorSpace
-      this.#renderControls()
     })
 
     // Reactive effects
@@ -677,6 +678,7 @@ export class ColorInput extends HTMLElement {
     if (!this.#controls) return
     const current = parseIntoChannels(space, this.#value.value)
     const ch = current.ch
+    const updaters: Array<(ch: ChannelRecord) => void> = []
 
     const channelSignals: Record<string, ReturnType<typeof signal<string>>> = {}
     Object.keys(ch).forEach(key => {
@@ -840,6 +842,23 @@ export class ColorInput extends HTMLElement {
               pendingApply = null
             }
           })
+        }
+      })
+
+      // Sync this control from an externally-changed value (area picker drags)
+      // without rebuilding the DOM
+      updaters.push((newCh) => {
+        const raw = newCh[key]
+        if (raw === undefined) return
+        ch[key] = raw
+        if (channelSignals[key]) channelSignals[key].value = String(raw)
+        range.value = String(raw)
+        if (isLabAB) {
+          const n = Number(raw)
+          if (signSup) signSup.textContent = n < 0 ? '−' : '+'
+          num.value = stripLeadingZeros(String(Math.abs(n)))
+        } else {
+          num.value = String(raw)
         }
       })
 
@@ -1014,6 +1033,23 @@ export class ColorInput extends HTMLElement {
         }
       })
     }
+
+    this.#controlsUpdate = (newCh) => {
+      batch(() => updaters.forEach((update) => update(newCh)))
+    }
+  }
+
+  // Sync existing control inputs from the current value without rebuilding the
+  // DOM — called on every area-picker change, including per-move during drags
+  #updateControls() {
+    if (!this.#controlsUpdate) {
+      this.#renderControls()
+      return
+    }
+    try {
+      const { ch } = parseIntoChannels(this.#space.value, this.#value.value)
+      this.#controlsUpdate(ch)
+    } catch { }
   }
 }
 


### PR DESCRIPTION
## What & why

Two hot paths in the picker were doing per-event work that could be done once (found while evaluating the GPU rendering question in #68 — these wins are GPU-agnostic and apply to the shipping component today):

1. **Every area-picker pointermove rebuilt the entire controls DOM.** The `AreaPicker` onChange callback called `#renderControls()`, which does `innerHTML = ''` and recreates every slider, number input, label, signal, and effect — at pointer-event rate during a drag.
2. **Every worker repaint allocated fresh canvas resources.** The worker `onmessage` handler created a new offscreen canvas per frame, copied the transferred pixel buffer twice (`createImageData` + `.set()`), and unconditionally assigned `canvas.width`/`height` — which reallocates and clears the backing store even when the size hasn't changed (it never changes during a hue drag).

## Changes

- Area-picker changes now sync the existing slider/number inputs **in place** (updaters registered per control, applied inside a signals `batch()`); the full rebuild still happens on colorspace change. Number-input formatting (lab/oklab sign superscript, leading-zero stripping) is preserved.
- Dropped the duplicate `#renderControls()` in the space `<select>` change listener — the `colorspace` setter already re-renders.
- Worker paint path: one offscreen scratch canvas reused across frames; the transferred pixel buffer is wrapped in `ImageData` directly (zero-copy, tagged `display-p3` so `putImageData` writes raw values); the visible canvas backing store is only reallocated when its size actually changes.

No visual or behavioral change intended — same rendered output, same worker traffic.

## Measured impact

Headless Chrome (Playwright, system Chrome channel) driving the real `<color-input>` on the docs dev server. Counters installed before any page script runs: a `MutationObserver` on `.controls`, patched `document.createElement`, canvas `width`/`height` setters, and `Worker` message counters. Each variant measured on a fresh page load; "before" = these two files from `main`.

**Area drag** — real CDP mouse drag (200 moves) + 500-move synchronous pointermove burst:

| metric | before | after |
|---|---|---|
| pointermove handler cost | 0.105 ms/move | **0.055 ms/move (1.9× faster)** |
| DOM nodes added/removed in `.controls` | 5,616 (8/move) | **0** |
| worst frame during drag | 58.1 ms | 35.7 ms (noisy) |

**Hue slider sweep** — 86 worker repaints in both runs:

| metric | before | after |
|---|---|---|
| offscreen canvases created | 86 (1/frame) | **0** |
| canvas backing-store reallocations | 344 (4/frame) | **0** |
| worker renders completed | 86 | 86 (unchanged) |

The deterministic counters are the strongest evidence: 8 top-level control nodes (~30 elements with listeners/effects underneath) replaced per pointermove, and ~1.5MB of retina backing store reallocated 4× per repaint frame — all gone. The halved handler time understates the real-browser win, since the timing can't capture the downstream style-recalc/layout and GC pressure the DOM churn causes, which is where this hurts at 120Hz pointer rates on slower hardware.

## Verification

- 438/438 vitest tests pass
- Benchmarked before/after as above (identical `value` progression and worker render counts in both runs confirm behavior parity)
- Visual QA: drag feel on the area picker + hue-slider scrub