### PR TITLE
Make footer color value field editable

### DIFF
--- a/src/color-input.ts
+++ b/src/color-input.ts
@@ -12,7 +12,7 @@ import {
 } from './color'
 import { AreaPicker } from './area-picker'
 import { formatChannel } from './utils/channel-formatting'
-import { gencolor, parseIntoChannels, type ChannelRecord } from './utils/color-conversion'
+import { gencolor, parseIntoChannels, preprocessColorInput, type ChannelRecord } from './utils/color-conversion'
 import {
   computeCandidates,
   findFirstFitOrMaxArea,
@@ -71,14 +71,23 @@ export class ColorInput extends HTMLElement {
   #areaPicker?: AreaPicker
   #programmaticUpdate = false
 
+  // Infer the working colorspace from a color string. Hex and functional
+  // notations express a format preference; named colors (`rebeccapurple`)
+  // don't, so they default to oklch rather than srgb.
+  #detectSpace(value: string, parsedSpaceId: string): ColorSpace {
+    const v = value.trim()
+    if (v.startsWith('#')) return 'hex'
+    if (/^[a-z]+$/i.test(v)) return DEFAULT_SPACE
+    const sid = reverseColorJSSpaceID(parsedSpaceId)
+    return sid === 'rgb' ? 'srgb' : (sid as ColorSpace)
+  }
+
   get value() { return this.#value.value }
   set value(v: string) {
     if (typeof v !== 'string' || !v) return
     try {
       const parsed = parse(v)
-      const sid = reverseColorJSSpaceID(parsed.spaceId)
-      const isHex = typeof v === 'string' && v.trim().startsWith('#')
-      this.#space.value = isHex ? 'hex' : (sid === 'rgb' ? 'srgb' : (sid as ColorSpace))
+      this.#space.value = this.#detectSpace(v, parsed.spaceId)
       this.#value.value = v
       this.#programmaticUpdate = true
       this.setAttribute('value', v)
@@ -157,12 +166,15 @@ export class ColorInput extends HTMLElement {
   #panel?: HTMLElement & { showPopover?: () => void; hidePopover?: () => void }
   #controls?: HTMLElement
   #spaceSelect?: HTMLSelectElement
-  #output?: HTMLOutputElement
+  #infoInput?: HTMLInputElement
   #chip?: HTMLElement
   #internalTrigger?: HTMLButtonElement
   #textInput?: HTMLInputElement
   #errorMessage?: HTMLElement
   #lastInvoker: HTMLElement | null = null
+  // While an editable color-string field has focus, reactive effects must not
+  // rewrite its text out from under the user's caret (re-sync happens on blur)
+  #editingField: HTMLInputElement | null = null
 
   constructor() {
     super()
@@ -195,7 +207,7 @@ export class ColorInput extends HTMLElement {
     this.#panel = this.#root.querySelector('.panel') as any
     this.#controls = this.#root.querySelector('.controls') as HTMLElement
     this.#spaceSelect = this.#root.querySelector('.space') as HTMLSelectElement
-    this.#output = this.#root.querySelector('output.info') as HTMLOutputElement
+    this.#infoInput = this.#root.querySelector('input.info') as HTMLInputElement
     this.#chip = this.#root.querySelector('.chip') as HTMLElement
     this.#textInput = this.#root.querySelector('.text-input') as HTMLInputElement
     this.#errorMessage = this.#root.querySelector('.error-message') as HTMLElement
@@ -306,13 +318,62 @@ export class ColorInput extends HTMLElement {
     if (this.#textInput) {
       this.#textInput.value = this.#value.value
 
-      this.#textInput.addEventListener('input', (e) => {
-        const inputValue = (e.target as HTMLInputElement).value
-        this.#validateAndSetColor(inputValue)
+      this.#textInput.addEventListener('focus', () => { this.#editingField = this.#textInput! })
+      this.#textInput.addEventListener('blur', () => {
+        this.#editingField = null
+        // Revert any uncommitted (invalid or unnormalized) text
+        this.#textInput!.value = this.#value.value
+        this.#error.value = null
       })
+      this.#textInput.addEventListener('input', () => {
+        const ok = this.#validateAndSetColor(this.#textInput!.value)
+        this.#error.value = ok ? null : 'Invalid color format'
+      })
+    }
 
-      this.#textInput.addEventListener('paste', (e) => {
-        // Allow default paste, then validate via input event
+    // Editable color string in the panel footer: paste/type any CSS color
+    if (this.#infoInput) {
+      this.#infoInput.value = this.#value.value
+      const setInvalid = (invalid: boolean) => this.#infoInput!.setAttribute('aria-invalid', String(invalid))
+
+      // First click selects the whole value (one-click paste target and copy
+      // source); once focused, further clicks place the caret normally.
+      // Safari collapses the focus-handler selection on the click's mouseup
+      // clearing the text selection, so suppress that first mouseup event.
+      let focusingClick = false
+      this.#infoInput.addEventListener('pointerdown', () => {
+        focusingClick = this.#editingField !== this.#infoInput
+      })
+      this.#infoInput.addEventListener('mouseup', (ev) => {
+        if (focusingClick) ev.preventDefault()
+        focusingClick = false
+      })
+      this.#infoInput.addEventListener('focus', () => {
+        this.#editingField = this.#infoInput!
+        this.#infoInput!.select()
+      })
+      this.#infoInput.addEventListener('blur', () => {
+        this.#editingField = null
+        this.#infoInput!.value = this.#value.value
+        setInvalid(false)
+      })
+      this.#infoInput.addEventListener('input', () => {
+        setInvalid(!this.#validateAndSetColor(this.#infoInput!.value))
+      })
+      this.#infoInput.addEventListener('keydown', (ev: KeyboardEvent) => {
+        const info = this.#infoInput!
+        if (ev.key === 'Enter') {
+          ev.preventDefault()
+          info.blur()
+        } else if (ev.key === 'Escape' && info.value !== this.#value.value) {
+          // First Escape reverts an in-progress edit and keeps the popover
+          // open; with the field clean, Escape falls through and closes it
+          ev.preventDefault()
+          ev.stopPropagation()
+          info.value = this.#value.value
+          setInvalid(false)
+          info.select()
+        }
       })
     }
 
@@ -354,9 +415,11 @@ export class ColorInput extends HTMLElement {
       const v = this.#value.value
       const gamut = this.#gamut.value
       const contrast = this.#contrast.value
-      if (this.#output) this.#output.value = v
+      if (this.#infoInput && this.#editingField !== this.#infoInput && this.#infoInput.value !== v) {
+        this.#infoInput.value = v
+      }
       if (this.#chip) this.#chip.style.setProperty('--value', v)
-      if (this.#textInput && this.#textInput.value !== v) {
+      if (this.#textInput && this.#editingField !== this.#textInput && this.#textInput.value !== v) {
         this.#textInput.value = v
       }
       this.style.setProperty('--contrast', contrast)
@@ -445,10 +508,8 @@ export class ColorInput extends HTMLElement {
     if (name === 'value' && typeof value === 'string') {
       try {
         const parsed = parse(value)
-        const sid = reverseColorJSSpaceID(parsed.spaceId)
-        const isHex = typeof value === 'string' && value.trim().startsWith('#')
         this.#value.value = value
-        this.#space.value = isHex ? 'hex' : (sid === 'rgb' ? 'srgb' : (sid as ColorSpace))
+        this.#space.value = this.#detectSpace(value, parsed.spaceId)
         if (this.#spaceSelect) this.#spaceSelect.value = this.#space.value
       } catch { }
     }
@@ -470,29 +531,29 @@ export class ColorInput extends HTMLElement {
     this.dispatchEvent(new CustomEvent<ChangeDetail>('change', { detail, bubbles: true }))
   }
 
-  #validateAndSetColor(inputValue: string) {
-    if (!inputValue || !inputValue.trim()) {
-      this.#error.value = 'Invalid color format'
-      return
-    }
+  #validateAndSetColor(rawValue: string): boolean {
+    const inputValue = preprocessColorInput(rawValue ?? '')
+    if (!inputValue) return false
 
     try {
       const parsed = parse(inputValue)
-      const sid = reverseColorJSSpaceID(parsed.spaceId)
-      const isHex = typeof inputValue === 'string' && inputValue.trim().startsWith('#')
-
-      // Clear error on success
-      this.#error.value = null
+      const nextSpace = this.#detectSpace(inputValue, parsed.spaceId)
+      const spaceChanged = nextSpace !== this.#space.value
 
       // Update value and colorspace
-      this.#space.value = isHex ? 'hex' : (sid === 'rgb' ? 'srgb' : (sid as ColorSpace))
+      this.#space.value = nextSpace
       this.#value.value = inputValue
       this.setAttribute('value', inputValue)
-      this.setAttribute('colorspace', this.#space.value)
-      if (this.#spaceSelect) this.#spaceSelect.value = this.#space.value
+      this.setAttribute('colorspace', nextSpace)
+      if (this.#spaceSelect) this.#spaceSelect.value = nextSpace
       this.#emitChange()
-    } catch (error) {
-      this.#error.value = 'Invalid color format'
+
+      // Keep sliders and numeric inputs in step with the committed string
+      if (spaceChanged) this.#renderControls()
+      else this.#updateControls()
+      return true
+    } catch {
+      return false
     }
   }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -228,7 +228,7 @@ button {
   box-shadow: 0 0px 1px 1px rgba(0,0,0,.25), inset 0 1px 2px rgba(0,0,0,.15);
 }
 
-/* Preview area: visual swatch + colorspace selector + current value output + gamut badge */
+/* Preview area: visual swatch + colorspace selector + current value field + gamut badge */
 .preview {
   position: relative;
   min-inline-size: 35ch;
@@ -340,7 +340,7 @@ button {
 }
 
 /* Gamut badge: displays detected color gamut (srgb/p3/rec2020/xyz) */
-/* Info output: shows the current CSS color string */
+/* Info input: edits the current CSS color string */
 .space {
   font-size: 0.8125rem;
   letter-spacing: 0.01em;
@@ -356,6 +356,30 @@ button {
   display: block;
   color: var(--contrast);
   background: transparent;
+
+  /* Editable: an input sitting directly on the live color swatch */
+  appearance: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  inline-size: 100%;
+  caret-color: var(--contrast);
+  border-radius: 2px;
+  outline-offset: 4px;
+
+  &::selection {
+    background: color-mix(in oklab, var(--contrast), transparent 75%);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--contrast), transparent 50%);
+  }
+
+  /* Invalid affordance is the outline: text-decoration does not render
+     inside inputs in Blink. Invalid state only exists while editing. */
+  &[aria-invalid="true"] {
+    outline: 2px solid color-mix(in oklab, red, var(--contrast) 25%);
+  }
 }
 
 /* color() syntax spaces produce longer strings — scale font fluidly */

--- a/src/utils/color-conversion.ts
+++ b/src/utils/color-conversion.ts
@@ -87,6 +87,35 @@ export function gencolor(space: ColorSpace, ch: ChannelRecord): string {
 }
 
 /**
+ * Normalize user-entered or pasted color text before parsing.
+ * Tolerates common clipboard artifacts: surrounding whitespace,
+ * zero-width characters, a full CSS declaration
+ * (`color: oklch(70% 0.1 220);`), a trailing semicolon, and bare hex
+ * digits without a leading `#`.
+ *
+ * @param raw - The raw text as typed or pasted
+ * @returns Cleaned string ready for colorjs.io `parse()`
+ *
+ * @example
+ * preprocessColorInput('  background-color: rgb(255 0 0);  ')
+ * // → 'rgb(255 0 0)'
+ *
+ * @example
+ * preprocessColorInput('ff6600')
+ * // → '#ff6600'
+ */
+export function preprocessColorInput(raw: string): string {
+  let s = raw.replace(/[\u200B-\u200D\u2060\uFEFF]/g, '').trim()
+  // Strip a CSS property prefix so pasting a whole declaration works
+  s = s.replace(/^[\w-]+\s*:\s*/, '')
+  // Strip a trailing semicolon
+  s = s.replace(/\s*;+$/, '')
+  // Bare hex without a `#` (3/4/6/8 digits)
+  if (/^(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(s)) s = `#${s}`
+  return s
+}
+
+/**
  * Parse a CSS color string into its component channels for a target color space.
  * Converts between spaces if necessary, normalizes channel ranges, and handles missing hue.
  *

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -39,7 +39,7 @@ export function createTemplate(): HTMLTemplateElement {
         </button>
       </div>
       <select class="space" title="Colorspace"></select>
-      <output class="info" part="output"></output>
+      <input type="text" class="info" part="output" aria-label="Color value" title="Edit color value" aria-invalid="false" spellcheck="false" autocomplete="off" autocapitalize="off" enterkeyhint="done" />
       <span class="gamut" title="Color's gamut" part="gamut"><span class="gamut-track"><span>srgb</span><span>p3</span><span>rec2020</span><span>xyz</span></span></span>
       <div class="contrast-scores">
         <span class="cr-w" title="WCAG 2.1 contrast ratio vs white"></span>

--- a/tests/09-copy.test.ts
+++ b/tests/09-copy.test.ts
@@ -12,9 +12,9 @@ describe('copy to clipboard behavior', () => {
   let el: any
   beforeEach(() => { el = makeEl(); el.show() })
 
-  it('output contains the current color string', async () => {
+  it('info field contains the current color string', async () => {
     el.value = 'hsl(200 100% 50%)'
-    const out = el.shadowRoot.querySelector('output.info') as HTMLOutputElement
+    const out = el.shadowRoot.querySelector('input.info') as HTMLInputElement
     expect(out.value).toContain('hsl(')
   })
 })

--- a/tests/21-info-input-editing.test.ts
+++ b/tests/21-info-input-editing.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import './setup'
+import '../src/index'
+
+function makeEl() {
+  const el = document.createElement('color-input') as any
+  document.body.appendChild(el)
+  return el
+}
+
+describe('editable color string in panel footer', () => {
+  let el: any
+  beforeEach(() => { el = makeEl(); el.show() })
+
+  function getInfo() {
+    return el.shadowRoot.querySelector('input.info') as HTMLInputElement
+  }
+
+  it('shows the current color and stays in sync with programmatic changes', () => {
+    const info = getInfo()
+    expect(info.value).toBe(el.value)
+    el.value = 'hsl(200 100% 50%)'
+    expect(info.value).toBe('hsl(200 100% 50%)')
+  })
+
+  it('commits a valid typed color live and emits change', () => {
+    const info = getInfo()
+    const changes: any[] = []
+    el.addEventListener('change', (event: Event) => {
+      changes.push((event as CustomEvent).detail)
+    })
+
+    info.value = '#ff6600'
+    info.dispatchEvent(new Event('input'))
+
+    expect(el.value).toBe('#ff6600')
+    expect(el.colorspace).toBe('hex')
+    expect(info.getAttribute('aria-invalid')).toBe('false')
+    expect(changes[changes.length - 1]).toEqual({
+      value: '#ff6600',
+      colorspace: 'hex',
+      gamut: 'srgb',
+    })
+  })
+
+  it('switches the colorspace select and rebuilds controls for a pasted format', () => {
+    const info = getInfo()
+    info.value = 'hsl(120 50% 50%)'
+    info.dispatchEvent(new Event('input'))
+
+    expect(el.colorspace).toBe('hsl')
+    const select = el.shadowRoot.querySelector('select.space') as HTMLSelectElement
+    expect(select.value).toBe('hsl')
+    // hsl controls include a saturation channel
+    expect(el.shadowRoot.querySelector('.controls input.ch-s')).not.toBeNull()
+  })
+
+  it('defaults named CSS colors to oklch instead of srgb', () => {
+    const info = getInfo()
+    // Move to a format-expressing space first
+    info.value = '#ff6600'
+    info.dispatchEvent(new Event('input'))
+    expect(el.colorspace).toBe('hex')
+
+    // A named color carries no format preference
+    info.value = 'rebeccapurple'
+    info.dispatchEvent(new Event('input'))
+    expect(el.value).toBe('rebeccapurple')
+    expect(el.colorspace).toBe('oklch')
+    // oklch controls include a chroma channel
+    expect(el.shadowRoot.querySelector('.controls input.ch-c')).not.toBeNull()
+  })
+
+  it('marks invalid input without changing the current color', () => {
+    const info = getInfo()
+    const before = el.value
+    info.value = 'not-a-color'
+    info.dispatchEvent(new Event('input'))
+
+    expect(info.getAttribute('aria-invalid')).toBe('true')
+    expect(el.value).toBe(before)
+  })
+
+  it('does not set the host-level error state for panel field input', () => {
+    const info = getInfo()
+    info.value = 'garbage'
+    info.dispatchEvent(new Event('input'))
+    expect(el.hasAttribute('data-error')).toBe(false)
+  })
+
+  it('selects the whole value on focus', () => {
+    const info = getInfo()
+    info.focus()
+    info.dispatchEvent(new Event('focus'))
+    expect(info.selectionStart).toBe(0)
+    expect(info.selectionEnd).toBe(info.value.length)
+  })
+
+  it('reverts uncommitted text and clears invalid state on blur', () => {
+    const info = getInfo()
+    const before = el.value
+    info.dispatchEvent(new Event('focus'))
+    info.value = 'oklch(nope'
+    info.dispatchEvent(new Event('input'))
+    expect(info.getAttribute('aria-invalid')).toBe('true')
+
+    info.dispatchEvent(new Event('blur'))
+    expect(info.value).toBe(before)
+    expect(info.getAttribute('aria-invalid')).toBe('false')
+  })
+
+  it('does not rewrite the field text from external updates while editing', () => {
+    const info = getInfo()
+    info.dispatchEvent(new Event('focus'))
+    info.value = 'oklch(70% 0'
+    info.dispatchEvent(new Event('input'))
+
+    // An external programmatic change arrives mid-edit
+    el.value = '#123456'
+    expect(info.value).toBe('oklch(70% 0')
+
+    // Blur re-syncs to the current value
+    info.dispatchEvent(new Event('blur'))
+    expect(info.value).toBe('#123456')
+  })
+
+  it('Escape reverts a dirty edit without closing the popover', () => {
+    const info = getInfo()
+    const before = el.value
+    info.dispatchEvent(new Event('focus'))
+    info.value = 'hsl(1'
+    info.dispatchEvent(new Event('input'))
+
+    const ev = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true })
+    info.dispatchEvent(ev)
+    expect(ev.defaultPrevented).toBe(true)
+    expect(info.value).toBe(before)
+    expect(info.getAttribute('aria-invalid')).toBe('false')
+  })
+
+  it('Escape falls through when the field is clean', () => {
+    const info = getInfo()
+    const ev = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true })
+    info.dispatchEvent(ev)
+    expect(ev.defaultPrevented).toBe(false)
+  })
+
+  describe('paste normalization', () => {
+    it('accepts a full CSS declaration', () => {
+      const info = getInfo()
+      info.value = '  color: rgb(255 0 0);  '
+      info.dispatchEvent(new Event('input'))
+      expect(el.value).toBe('rgb(255 0 0)')
+      expect(el.colorspace).toBe('srgb')
+    })
+
+    it('accepts bare hex without a leading #', () => {
+      const info = getInfo()
+      info.value = 'ff6600'
+      info.dispatchEvent(new Event('input'))
+      expect(el.value).toBe('#ff6600')
+      expect(el.colorspace).toBe('hex')
+    })
+
+    it('strips zero-width characters from pasted strings', () => {
+      const info = getInfo()
+      info.value = '​#ff6600﻿'
+      info.dispatchEvent(new Event('input'))
+      expect(el.value).toBe('#ff6600')
+    })
+  })
+})

--- a/tests/unit/color-conversion.test.ts
+++ b/tests/unit/color-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { gencolor, parseIntoChannels } from '../../src/utils/color-conversion'
+import { gencolor, parseIntoChannels, preprocessColorInput } from '../../src/utils/color-conversion'
 import type { ColorSpace } from '../../src/color'
 
 describe('color-conversion', () => {
@@ -159,6 +159,21 @@ describe('color-conversion', () => {
         expect(gencolor('hsl', {})).toBe('hsl(0 0% 50%)')
         expect(gencolor('srgb', {})).toBe('rgb(0% 0% 0%)')
       })
+    })
+  })
+
+  describe('preprocessColorInput', () => {
+    it('should trim whitespace and invisible characters', () => {
+      expect(preprocessColorInput(' \u200B#ff6600\uFEFF ')).toBe('#ff6600')
+    })
+
+    it('should strip CSS declaration wrappers', () => {
+      expect(preprocessColorInput('background-color: rgb(255 0 0);')).toBe('rgb(255 0 0)')
+    })
+
+    it('should add a hash to bare hex colors', () => {
+      expect(preprocessColorInput('ff6600')).toBe('#ff6600')
+      expect(preprocessColorInput('f60')).toBe('#f60')
     })
   })
 

--- a/tests/unit/template.test.ts
+++ b/tests/unit/template.test.ts
@@ -78,11 +78,13 @@ describe('template', () => {
       expect(select?.getAttribute('title')).toBe('Colorspace')
     })
 
-    it('should include output element', () => {
+    it('should include editable info input', () => {
       const template = createTemplate()
-      const output = template.content.querySelector('output.info')
-      expect(output).not.toBeNull()
-      expect(output?.getAttribute('part')).toBe('output')
+      const info = template.content.querySelector('input.info')
+      expect(info).not.toBeNull()
+      expect(info?.getAttribute('part')).toBe('output')
+      expect(info?.getAttribute('aria-label')).toBe('Color value')
+      expect(info?.getAttribute('spellcheck')).toBe('false')
     })
 
     it('should include gamut badge', () => {


### PR DESCRIPTION
This is the proposed 2nd part of argyleink/css-color-component#2

I replaced the preview footer `<output>` with an editable `input.info` and hooked it up to do live color commits on valid text values, as well as adding invalid-state feedback, focus/blur selection behavior, and Escape/Enter editing UX.

I also added input-preprocessing via `preprocessColorInput` to normalize pasted/typed values (trim invisibles, strip CSS declarations/semicolons, accept bare hex), and centralized the colorspace detection into a new `#detectSpace` method so that color formats that correspond to particular colorspaces are respected. I carved out an exception for CSS named colors (e.g. `black`) so that they default to the `oklch` colorspace, because I feel like it’s better UX to encourage users to take advantage of HDR colorspaces.

Lastly, I updated styles and expanded integration/unit tests to cover editing flow, sync behavior, colorspace switching, and preprocessing.

Here’s a quick recording:

https://github.com/user-attachments/assets/a395d20b-ea06-48d0-902b-525b3b0da40d

The UX decisions are based on the color-picker survey I posted in https://github.com/argyleink/css-color-component/issues/2#issuecomment-4948631739, including live commit with inert invalid state (Chrome DevTools, oklch.com) and select-all on focus (Sketch, Figma).

To answer the issues/questions you raised in the issue thread:

- **Architecture:** It’s a small change. The validate/commit plumbing already existed for the host text input, so the footer field reuses it. There were two things that needed some extra work:
    1. committing a value in a different colorspace never rebuilt the channel sliders (a pre-existing bug on main; type `hsl(120 50% 50%)` into the host text input while in oklch and open the popover: the sliders still show L/C/H and dragging one re-serializes in the old space). `#validateAndSetColor` now re-renders controls on a space change and syncs slider positions otherwise.
    2. The reactive effect that writes the value into the field is suppressed while the field has focus, so re-serialization doesn’t fight the user’s caret; the fields re-sync on blur.
- **Accessibility:** the field has an `aria-label`, sets `aria-invalid` while an edit doesn’t parse (with a visible outline drawn in the swatch’s contrast color), and uses `enterkeyhint="done"`. Enter commits and blurs; the first Escape reverts an in-progress edit without closing the popover.
- **Copy button:** I kept it. The survey’s clearest finding was that removing an explicit copy affordance leads to grief (it’s Figma’s most-requested picker feature, and the bare macOS panel spawned a third-party app category). Select-all-on-focus makes manual copy easy, but the button is still fewer steps and works on touch.

One behavior change beyond the footer field that you should know about: colorspace detection is shared with the `value` property/attribute, so `value="tomato"` now lands in oklch rather than srgb. Hex and functional notations behave as before.

I verified the new behavior in Chrome and Safari 26.5 (both desktop). With the select-all-on-focus behavior, Safari collapses a focus-time selection on the same click’s mouseup, so I added a guard to `preventDefault` the event for that instance of it.